### PR TITLE
Make interest calculation implementation-agnostic.

### DIFF
--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -244,9 +244,20 @@ public class MvcController {
   }
 
   // Converts LocalDateTime to Date variable
-  private static Date convertLocalDateTimeToDate(LocalDateTime ldt){
+  private static Date convertLocalDateTimeToDate(LocalDateTime ldt) {
     Date dateTime = Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
     return dateTime;
+  }
+  
+  
+  /**
+   * Applies going interest rate to {@code pennyAmount}.
+   * 
+   * @param pennyAmount
+   * @return {@code pennyAmount} plus interest
+   */
+  private static int applyInterestRateToPennyAmount(int pennyAmount) {
+    return (int) (pennyAmount * INTEREST_RATE);
   }
 
   // HTML POST HANDLERS ////
@@ -407,7 +418,7 @@ public class MvcController {
     int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
     if (userWithdrawAmtInPennies > userBalanceInPennies) { // if withdraw amount exceeds main balance, withdraw into overdraft with interest fee
       int excessWithdrawAmtInPennies = userWithdrawAmtInPennies - userBalanceInPennies;
-      int newOverdraftIncreaseAmtAfterInterestInPennies = (int)(excessWithdrawAmtInPennies * INTEREST_RATE);
+      int newOverdraftIncreaseAmtAfterInterestInPennies = applyInterestRateToPennyAmount(excessWithdrawAmtInPennies);
       int newOverdraftBalanceInPennies = userOverdraftBalanceInPennies + newOverdraftIncreaseAmtAfterInterestInPennies;
 
       // abort withdraw transaction if new overdraft balance exceeds max overdraft limit

--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -249,6 +249,16 @@ public class MvcController {
     return dateTime;
   }
 
+  /**
+   * Applies going interest rate to {@code pennyAmount}.
+   * 
+   * @param pennyAmount
+   * @return {@code pennyAmount} plus interest
+   */
+  private static int applyInterestRateToPennyAmount(int pennyAmount) {
+    return (int) (pennyAmount * INTEREST_RATE);
+  }
+
   // HTML POST HANDLERS ////
 
   /**
@@ -407,7 +417,7 @@ public class MvcController {
     int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
     if (userWithdrawAmtInPennies > userBalanceInPennies) { // if withdraw amount exceeds main balance, withdraw into overdraft with interest fee
       int excessWithdrawAmtInPennies = userWithdrawAmtInPennies - userBalanceInPennies;
-      int newOverdraftIncreaseAmtAfterInterestInPennies = (int)(excessWithdrawAmtInPennies * INTEREST_RATE);
+      int newOverdraftIncreaseAmtAfterInterestInPennies = applyInterestRateToPennyAmount(excessWithdrawAmtInPennies);
       int newOverdraftBalanceInPennies = userOverdraftBalanceInPennies + newOverdraftIncreaseAmtAfterInterestInPennies;
 
       // abort withdraw transaction if new overdraft balance exceeds max overdraft limit

--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -244,20 +244,9 @@ public class MvcController {
   }
 
   // Converts LocalDateTime to Date variable
-  private static Date convertLocalDateTimeToDate(LocalDateTime ldt) {
+  private static Date convertLocalDateTimeToDate(LocalDateTime ldt){
     Date dateTime = Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
     return dateTime;
-  }
-  
-  
-  /**
-   * Applies going interest rate to {@code pennyAmount}.
-   * 
-   * @param pennyAmount
-   * @return {@code pennyAmount} plus interest
-   */
-  private static int applyInterestRateToPennyAmount(int pennyAmount) {
-    return (int) (pennyAmount * INTEREST_RATE);
   }
 
   // HTML POST HANDLERS ////
@@ -418,7 +407,7 @@ public class MvcController {
     int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
     if (userWithdrawAmtInPennies > userBalanceInPennies) { // if withdraw amount exceeds main balance, withdraw into overdraft with interest fee
       int excessWithdrawAmtInPennies = userWithdrawAmtInPennies - userBalanceInPennies;
-      int newOverdraftIncreaseAmtAfterInterestInPennies = applyInterestRateToPennyAmount(excessWithdrawAmtInPennies);
+      int newOverdraftIncreaseAmtAfterInterestInPennies = (int)(excessWithdrawAmtInPennies * INTEREST_RATE);
       int newOverdraftBalanceInPennies = userOverdraftBalanceInPennies + newOverdraftIncreaseAmtAfterInterestInPennies;
 
       // abort withdraw transaction if new overdraft balance exceeds max overdraft limit


### PR DESCRIPTION
The original controller code calculates the overdraft fee by explicitly referencing the static literal `INTEREST_RATE` inline. This approach is brittle: if we ever want to change how the interest rate is determined (e.g. retrieving it using an API), we would have to manually update this line (and any future lines which might reference the interest rate) to reflect that.

By refactoring the interest rate to a separate method, we give ourselves more flexibility to change this implementation in the future while reducing the maintenance burden.