### PR TITLE
Add Solana/invalid currency integration tests.

### DIFF
--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1582,4 +1582,109 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
+    /**
+   * Test the Buy ETH, Buy SOL, Sell SOL user flow
+   */
+  @Test
+  public void testCryptoBuyETHBuySolSellSol() throws ScriptException, InterruptedException {
+    /* TODO: the only reason this test passes consistently is because execution is manually paused for 1 second
+     * between each transaction to prevent them from getting the same timestamp and messing up transaction
+     * log ordering, which is used by CryptoTransactionTester to fetch the most recent transaction.
+     * 
+     * THIS SHOULD **NOT** BE LEFT AS IS, and can only be properly addressed by giving a more precise
+     * absolute ordering for transactions, perhaps by issuing a unique transaction ID which increments for each
+     * transaction across the database or by increasing the precision of timestamps (they currently only seem
+     * to have a 1 second resolution).
+    */
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+        .initialBalanceInDollars(1000)
+        .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransactionBuyETH = CryptoTransaction.builder()
+        .expectedEndingBalanceInDollars(900)
+        .expectedEndingCryptoBalance(0.1)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+        .shouldSucceed(true)
+        .build();
+    cryptoTransactionTester.test(cryptoTransactionBuyETH);
+
+    Thread.sleep(1000);
+
+    CryptoTransaction cryptoTransactionBuySOL = CryptoTransaction.builder()
+          .expectedEndingBalanceInDollars(810)
+          .expectedEndingCryptoBalance(3.0)
+          .cryptoPrice(30)
+          .cryptoAmountToTransact(3.0)
+          .cryptoName("SOL")
+          .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+          .shouldSucceed(true)
+          .build();
+    cryptoTransactionTester.test(cryptoTransactionBuySOL);
+
+    Thread.sleep(1000);
+
+    CryptoTransaction cryptoTransactionSellSOL = CryptoTransaction.builder()
+        .expectedEndingBalanceInDollars(850)
+        .expectedEndingCryptoBalance(2.0)
+        .cryptoPrice(40)
+        .cryptoAmountToTransact(1.0)
+        .cryptoName("SOL")
+        .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+        .shouldSucceed(true)
+        .build();
+    cryptoTransactionTester.test(cryptoTransactionSellSOL);
+  }
+
+  /**
+   * Test that buying an unsupported cryptocurrency (BTC) does not modify
+   * the user's account and simply redirects them to the welcome page.
+   */
+  @Test
+  public void testCryptoBuyInvalidCurrency() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+        .initialBalanceInDollars(1000)
+        .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+        .expectedEndingBalanceInDollars(1000)
+        .expectedEndingCryptoBalance(0.0)
+        .cryptoPrice(-1)
+        .cryptoAmountToTransact(1.0)
+        .cryptoName("BTC")
+        .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+        .shouldSucceed(false)
+        .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+  /**
+   * Test that selling an unsupported cryptocurrency (BTC) does not modify
+   * the user's account and simply redirects them to the welcome page.
+   */
+  @Test
+  public void testCryptoSellInvalidCurrency() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+        .initialBalanceInDollars(1000)
+        .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+        .expectedEndingBalanceInDollars(1000)
+        .expectedEndingCryptoBalance(0.0)
+        .cryptoPrice(-1)
+        .cryptoAmountToTransact(1.0)
+        .cryptoName("BTC")
+        .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+        .shouldSucceed(false)
+        .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
 }


### PR DESCRIPTION
I've added integration tests which handle a basic user flow of buying and selling multiple cryptocurrencies (in particular the two currently supported, Ethereum and Solana) in one session as well as ensuring that the application safely handles attempted transactions for unsupported currencies. The tests themselves are fairly unremarkable, but in writing them I discovered a serious flaw at the heart of our transaction logging system, described below.

---

In writing the first test which handles multiple transactions, I encountered many strange and inconsistent errors; in some cases, running the test multiple times without modification would result in different results (sometimes different errors, sometimes even passing). After poring over the code for a while, I found the culprit in `CryptoTransactionTester.test()`:

https://github.com/s1ddh4rthc/testudo-bank/blob/8a0835f8bc603df3d7f5148a52e77f1e63caeca9/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java#L1289-L1294

The code here assumes that timestamps can be used to establish an absolute chronological ordering of transactions. However, since timestamps only have precision down to the second and computers can perform multiple transactions in a fraction of a second, this ordering cannot be relied upon, since it's highly likely two transactions performed in quick succession will have the same timestamp. For instance, here is the state of the transaction log after performing the three transactions in my test when sorted by timestamp descending:

CustomerID=123456789, Timestamp=2022-11-04T21:50:45, Action=Buy, CryptoName=SOL, CryptoAmount=3.000000000000000000
CustomerID=123456789, Timestamp=2022-11-04T21:50:45, Action=Sell, CryptoName=SOL, CryptoAmount=1.000000000000000000
CustomerID=123456789, Timestamp=2022-11-04T21:50:44, Action=Buy, CryptoName=ETH, CryptoAmount=0.100000000000000000

Even though the sell SOL transaction occurred after the buy SOL transaction, they ended up with the same timestamp, and the way the tiebreaker is handled happens to put the buy transaction before it when sorted. When the sell transaction is tested in this case, the above code will end up grabbing the buy SOL transaction, causing a test failure (since the transaction types will not match, among other things). In order to make the test pass consistently I added a 1 second delay between each transaction, but this is untenable—we must implement a more robust ordering of transactions.

I think the clearest solution is adding an incrementing transaction ID, but we could also use a more precise timestamp. Each has their own pros and cons--the transaction ID plan is unambiguous, but may not scale or present synchronization issues if the application is parallelized. The timestamp plan may be simpler to implement, but it may only reduce the chance of collision rather than eliminate it outright. Careful consideration is required.