### PR TITLE
apply interest rate to account balance on every 5th significant deposit

### DIFF
--- a/python-sql-scripts/addCustomers.py
+++ b/python-sql-scripts/addCustomers.py
@@ -51,7 +51,7 @@ create_transactionhistory_table_sql = '''
 CREATE TABLE TransactionHistory (
   CustomerID varchar(255),
   Timestamp DATETIME,
-  Action varchar(255) CHECK (Action IN ('Deposit', 'Withdraw', 'TransferSend', 'TransferReceive', 'CryptoBuy', 'CryptoSell')),
+  Action varchar(255) CHECK (Action IN ('Deposit', 'DepositInterest', 'Withdraw', 'TransferSend', 'TransferReceive', 'CryptoBuy', 'CryptoSell')),
   Amount int
 );
 '''

--- a/python-sql-scripts/addCustomers.py
+++ b/python-sql-scripts/addCustomers.py
@@ -2,6 +2,7 @@ import pymysql
 import names
 import random
 import string
+import datetime
 from credentials import mysql_endpoint, username, password, database_name
 
 # SQL Config Values
@@ -68,6 +69,26 @@ CREATE TABLE TransferHistory (
 '''
 cursor.execute(create_transferhistory_table_sql)
 
+# Make empty AvailableCertificateOfDeposits table
+create_availablecertificateofdeposits_table_sql = '''
+CREATE TABLE AvailableCertificateOfDeposits (
+  CertificateID varchar(255),
+  MaturityDate DATETIME,
+  AmountAvailable int
+);
+'''
+cursor.execute(create_availablecertificateofdeposits_table_sql)
+
+
+certificateofdeposit_id = ''.join(random.choices(string.digits, k = 9))
+value1 = datetime.datetime(2024, 4, 27)
+insert_availablecertificateofdeposits_sql = '''
+    INSERT INTO AvailableCertificateOfDeposits
+    VALUES  ('{0}','{1}',{2});
+    '''.format(certificateofdeposit_id,
+              value1,
+              100)
+cursor.execute(insert_availablecertificateofdeposits_sql)
 
 # Make empty CryptoHoldings table
 create_cryptoholdings_table_sql = '''

--- a/src/main/java/net/testudobank/TestudoBankRepository.java
+++ b/src/main/java/net/testudobank/TestudoBankRepository.java
@@ -51,6 +51,12 @@ public class TestudoBankRepository {
     return transactionLogs;
   }
 
+  public static List<Map<String, Object>> getAvailableCertificatesofDeposit(JdbcTemplate jdbcTemplate) {
+    String getAvailableCDsSql = "SELECT * FROM AvailableCertificateOfDeposits;";
+    List<Map<String,Object>> availableCDs = jdbcTemplate.queryForList(getAvailableCDsSql);
+    return availableCDs;
+  }
+
   public static List<Map<String,Object>> getTransferLogs(JdbcTemplate jdbcTemplate, String customerID, int numTransfersToFetch) {
     String getTransferHistorySql = String.format("Select * from TransferHistory WHERE TransferFrom='%s' OR TransferTo='%s' ORDER BY Timestamp DESC LIMIT %d;", customerID, customerID, numTransfersToFetch);
     List<Map<String,Object>> transferLogs = jdbcTemplate.queryForList(getTransferHistorySql);

--- a/src/main/java/net/testudobank/User.java
+++ b/src/main/java/net/testudobank/User.java
@@ -35,6 +35,15 @@ public class User {
   @Setter @Getter
   private String transactionHist;
 
+  @Setter @Getter
+  private String availableCDs;
+
+  @Setter @Getter
+  private String CDHoldings;
+
+  @Setter @Getter
+  private double holdingsQuantity;
+
   //// Dispute Fields ////
 
   @Setter @Getter
@@ -78,8 +87,20 @@ public class User {
   @Setter @Getter @Positive
   private double amountToSellCrypto;
 
+  @Setter @Getter @Positive
+  private double amountToBuyCD;
+
+  @Setter @Getter @Positive
+  private double amountToSellCD;
+
   @Setter @Getter
   private String whichCryptoToBuy;
+
+  @Setter @Getter
+  private String whichCDToBuy;
+
+  @Setter @Getter
+  private String whichCDToSell;
 
   @Setter @Getter
   private double ethPrice;

--- a/src/main/webapp/WEB-INF/views/account_info.jsp
+++ b/src/main/webapp/WEB-INF/views/account_info.jsp
@@ -42,6 +42,7 @@
     <span>Transaction History: </span><span>${user.transactionHist}</span><br/>
     <span>Transfer History: </span><span>${user.transferHist}</span><br/>
     <span>Crypto History: </span><span>${user.cryptoHist}</span><br/>
+    <span>CD Holdings: </span> <span>${user.CDHoldings}</span><br/>
     <br/>
     <a href='/deposit'>Deposit</a>
     <a href='/withdraw'>Withdraw</a>

--- a/src/main/webapp/WEB-INF/views/buycertificateofdeposit_form.jsp
+++ b/src/main/webapp/WEB-INF/views/buycertificateofdeposit_form.jsp
@@ -6,7 +6,7 @@
 <head>
   <link rel="icon" href="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png">
   <meta charset="ISO-8859-1">
-  <title>Welcome Page</title>
+  <title>Buy CD Form</title>
   <style type="text/css">
     label {
       display: inline-block;
@@ -33,22 +33,26 @@
     }
   </style>
 </head>
-
 <body>
 	<div align="center">
-		<h2>Welcome to Testudo Bank!</h2>
-        <img src="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png" style="float:left;width:100px;height:100px;">
-		<a href='/login'>View Account</a> <br/>
-    <a href='/deposit'>Deposit</a> <br/>
-    <a href='/withdraw'>Withdraw</a> <br/>
-    <a href='/dispute'>Dispute</a> <br/>
-    <a href='/transfer'>Transfer</a> <br/>
-    <a href='/buycertificateofdeposit'>Buy Certificate of Deposits</a>
-    <a href='/sellcertificateofdeposit'>Sell Certificate of Deposits</a> <br/>
-    <a href='/buycrypto'>Buy Cryptocurrency</a>
-    <a href='/sellcrypto'>Sell Cryptocurrency</a> <br/>
+		<form:form action="buycertificateofdeposit" method="post" modelAttribute="user">
+			<form:label path="username">Username:</form:label>
+			<form:input path="username"/><br/>
 
+			<form:label path="password">Password:</form:label>
+			<form:password path="password"/><br/>		
+
+      <form:label path="whichCDToBuy">Which CD to buy (id):</form:label>
+			<form:input path="whichCDToBuy"/><br/>
+
+      <form:label path="amountToBuyCD">Amount to buy (# of CDs):</form:label>
+			<form:input path="amountToBuyCD"/><br/>
+      
+      <span>Available CDs for purchase: </span><span>${user.availableCDs}</span><br/>
+
+			<form:button>Buy CD</form:button>
+		</form:form>
+    <a href='/'>Home</a>
 	</div>
 </body>
-
 </html>

--- a/src/main/webapp/WEB-INF/views/sellcertificateofdeposit_form.jsp
+++ b/src/main/webapp/WEB-INF/views/sellcertificateofdeposit_form.jsp
@@ -6,7 +6,7 @@
 <head>
   <link rel="icon" href="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png">
   <meta charset="ISO-8859-1">
-  <title>Welcome Page</title>
+  <title>Sell Certificate of Deposit Form</title>
   <style type="text/css">
     label {
       display: inline-block;
@@ -33,22 +33,24 @@
     }
   </style>
 </head>
-
 <body>
 	<div align="center">
-		<h2>Welcome to Testudo Bank!</h2>
-        <img src="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png" style="float:left;width:100px;height:100px;">
-		<a href='/login'>View Account</a> <br/>
-    <a href='/deposit'>Deposit</a> <br/>
-    <a href='/withdraw'>Withdraw</a> <br/>
-    <a href='/dispute'>Dispute</a> <br/>
-    <a href='/transfer'>Transfer</a> <br/>
-    <a href='/buycertificateofdeposit'>Buy Certificate of Deposits</a>
-    <a href='/sellcertificateofdeposit'>Sell Certificate of Deposits</a> <br/>
-    <a href='/buycrypto'>Buy Cryptocurrency</a>
-    <a href='/sellcrypto'>Sell Cryptocurrency</a> <br/>
+		<form:form action="sellcertificateofdeposit" method="post" modelAttribute="user">
+			<form:label path="username">Username:</form:label>
+			<form:input path="username"/><br/>
 
+			<form:label path="password">Password:</form:label>
+			<form:password path="password"/><br/>		
+
+      <form:label path="whichCDToSell">Which CD to sell (id):</form:label>
+			<form:input path="whichCDToSell"/><br/>
+
+      <form:label path="amountToSellCD">Amount to sell (# of CDs):</form:label>
+			<form:input path="amountToSellCD"/><br/>	
+
+			<form:button>Sell CD</form:button>
+		</form:form>
+    <a href='/'>Home</a>
 	</div>
 </body>
-
 </html>

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -256,6 +256,179 @@ public class MvcControllerIntegTest {
     MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
   }
 
+    /**
+   * Tests the edge case that interest is not applied for 5 deposits of $19.99
+   * The customer's balance should be increased for every deposit and the interest should not be applied on every 5th deposit
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testDepositInterestFor1999Deposits() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 100.00;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+
+    // Prepare Deposit Form to Deposit $19.99 to customer 1's account.
+    double CUSTOMER1_AMOUNT_TO_DEPOSIT = 19.99; // user input is in dollar amount, not pennies.
+    User customer1DepositFormInputs = new User();
+    customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
+    customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
+    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT); 
+
+    // verify that there are no logs in TransactionHistory table before Deposit
+    assertEquals(0, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
+
+    // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory table later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
+
+    // send request to the Deposit Form's POST handler in MvcController
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+
+    // fetch updated data from the DB
+    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
+  
+    // verify that customer1's data is still the only data populated in Customers table
+    assertEquals(1, customersTableData.size());
+    Map<String,Object> customer1Data = customersTableData.get(0);
+    assertEquals(CUSTOMER1_ID, (String)customer1Data.get("CustomerID"));
+
+    // verify customer balance was increased by $19.99, 5 times
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE = CUSTOMER1_BALANCE + (5.0 * CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE) - 5;
+    assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+
+    // verify that the 5 Deposits are the only logs in TransactionHistory table
+    assertEquals(5, transactionHistoryTableData.size());
+    
+    // verify that the Deposit's details are accurately logged in the TransactionHistory table
+    Map<String,Object> customer1TransactionLog = transactionHistoryTableData.get(0);
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+  }
+
+  /**
+   * Tests the edge case that interest is applied for the 5th deposit of $20.01
+   * The customer's balance should be increased for every deposit and the interest should be applied on every 5th deposit
+   * and subsequently the interest should be logged in the TransactionHistory table
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testDepositInterestFor2001Deposits() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 100.00;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+
+    // Prepare Deposit Form to Deposit $20.01 to customer 1's account.
+    double CUSTOMER1_AMOUNT_TO_DEPOSIT = 20.01; // user input is in dollar amount, not pennies.
+    User customer1DepositFormInputs = new User();
+    customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
+    customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
+    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT); 
+
+    // verify that there are no logs in TransactionHistory table before Deposit
+    assertEquals(0, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
+
+    // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory table later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
+
+    // send request to the Deposit Form's POST handler in MvcController
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+
+    // fetch updated data from the DB
+    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
+  
+    // verify that customer1's data is still the only data populated in Customers table
+    assertEquals(1, customersTableData.size());
+    Map<String,Object> customer1Data = customersTableData.get(0);
+    assertEquals(CUSTOMER1_ID, (String)customer1Data.get("CustomerID"));
+
+    // verify customer balance was increased by $20.01, 5 times and the interest was applied on the 5th deposit
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE = BALANCE_INTEREST_RATE * (CUSTOMER1_BALANCE + (5.0 * CUSTOMER1_AMOUNT_TO_DEPOSIT));
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
+    assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+
+    // verify that there are 5 Deposits logged in the TransactionHistory table along with a single DepositInterest log
+    assertEquals(6, transactionHistoryTableData.size());
+    
+    // verify that the Deposit's details are accurately logged in the TransactionHistory table
+    Map<String,Object> customer1TransactionLog = transactionHistoryTableData.get(0);
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+  }
+
+    /**
+   * Tests the edge case that interest is applied for the 5th deposit of $20.00
+   * The customer's balance should be increased for every deposit and the interest should be applied on every 5th deposit
+   * and subsequently the interest should be logged in the TransactionHistory table
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testDepositInterestFor2000Deposits() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 100.00;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+
+    // Prepare Deposit Form to Deposit $20.01 to customer 1's account.
+    double CUSTOMER1_AMOUNT_TO_DEPOSIT = 20.00; // user input is in dollar amount, not pennies.
+    User customer1DepositFormInputs = new User();
+    customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
+    customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
+    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT); 
+
+    // verify that there are no logs in TransactionHistory table before Deposit
+    assertEquals(0, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
+
+    // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory table later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
+
+    // send request to the Deposit Form's POST handler in MvcController
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+    controller.submitDeposit(customer1DepositFormInputs);
+
+    // fetch updated data from the DB
+    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
+  
+    // verify that customer1's data is still the only data populated in Customers table
+    assertEquals(1, customersTableData.size());
+    Map<String,Object> customer1Data = customersTableData.get(0);
+    assertEquals(CUSTOMER1_ID, (String)customer1Data.get("CustomerID"));
+
+    // verify customer balance was increased by $20.00, 5 times and the interest was applied on the 5th deposit
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE = BALANCE_INTEREST_RATE * (CUSTOMER1_BALANCE + (5.0 * CUSTOMER1_AMOUNT_TO_DEPOSIT));
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
+    assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+
+    // verify that there are 5 Deposits logged in the TransactionHistory table along with a single DepositInterest log
+    assertEquals(6, transactionHistoryTableData.size());
+    
+    // verify that the Deposit's details are accurately logged in the TransactionHistory table
+    Map<String,Object> customer1TransactionLog = transactionHistoryTableData.get(0);
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+  }
+
   /**
    * Tests the interest is not applied on every 5th deposit if there is overdraft
    * The customer's balance should be increased for every deposit and the interest should not be applied on every 5th deposit

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1923,4 +1923,97 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
+  /**
+   * Test the situation in which a customer with no pre-existing Crypto buys ETH, buys SOL, and then sells some of their SOL.
+   */
+  @Test
+  public void testCryptoBuySell() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("ETH")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+
+    cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(700)
+            .expectedEndingCryptoBalance(0.2)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.2)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+
+    cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(750)
+            .expectedEndingCryptoBalance(0.15)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.05)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+ /**
+   * Ensures that the "welcome" page is returned when a user attempts to put "BTC" as the crypto name in the front-end when filling out the CryptoBuy form.
+   */
+  @Test
+  public void testBuyBTCInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+            .build();
+
+    cryptoTransactionTester.initialize();
+      
+      CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+              .expectedEndingBalanceInDollars(1000)
+              .expectedEndingCryptoBalance(0)
+              .cryptoPrice(1000)
+              .cryptoAmountToTransact(0.1)
+              .cryptoName("BTC")
+              .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+              .shouldSucceed(false)
+              .build();
+      cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+  /**
+   * Ensures that the "welcome" page is returned when a user attempts to put "BTC" as the crypto name in the front-end when filling out the CryptoSell form.
+   */
+  @Test
+  public void testSellBTCInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+            .build();
+
+    cryptoTransactionTester.initialize();
+      
+      CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+              .expectedEndingBalanceInDollars(1000)
+              .expectedEndingCryptoBalance(0)
+              .cryptoPrice(1000)
+              .cryptoAmountToTransact(0.1)
+              .cryptoName("BTC")
+              .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+              .shouldSucceed(false)
+              .build();
+      cryptoTransactionTester.test(cryptoTransaction);
+  }
 }

--- a/src/test/resources/clearDB.sql
+++ b/src/test/resources/clearDB.sql
@@ -2,6 +2,7 @@ TRUNCATE Customers;
 TRUNCATE Passwords;
 TRUNCATE OverdraftLogs;
 TRUNCATE TransactionHistory;
+TRUNCATE AvailableCertificateOfDeposits;
 TRUNCATE TransferHistory;
 TRUNCATE CryptoHistory;
 TRUNCATE CryptoHoldings;

--- a/src/test/resources/createDB.sql
+++ b/src/test/resources/createDB.sql
@@ -28,6 +28,12 @@ CREATE TABLE TransactionHistory (
   Amount int
 );
 
+CREATE TABLE AvailableCertificateOfDeposits (
+  CertificateID varchar(255),
+  MaturityDate DATETIME,
+  AmountAvailable int
+);
+
 CREATE TABLE TransferHistory (
   TransferFrom varchar(255),
   TransferTo varchar(255),


### PR DESCRIPTION
**Changes made in this PR:**
I have allowed users to accrue an interest rate (1.5%) on their account balance for every 5th deposit they make over $20. This feature updates a field in the customer object called "numberOfDepositsForInterest" every time a deposit is made over $20 to keep track of the number of deposits and uses this to determine when to apply the 1.5% interest rate on the user's account balance.

src/main/java/net/testudobank/MvcController.java

- If the amount that we deposit is over $20, we increment the numberOfDepositsForInterest field in the database to count this deposit as one that contributes to the interest
- When this numberOfDepositsForInterest field is a multiple of 5, we know to apply the interest, and we apply a constant 1.5% interest on the account balance
- We also insert this interest application into the transactionHistory table as a "DepositInterest" action
- All of the above logic is now placed in a helper function called applyInterest.

src/test/java/net/testudobank/tests/MvcControllerIntegTest.java

- Added test for 5 deposits over $20, confirming that the interest rate is applied and logged in the transactionHistory table
- Added test for 5 deposits under $20, confirming that the interest rate is not applied and not logged in the transactionHistory table
- Added test for 5 deposits over $20 in overdraft condition, confirming that the interest rate is not applied and not logged in the transactionHistory table
- Added integ test for the edge case of 5 deposits of $19.99, confirming that the interest rate is not applied and not logged in the transactionHistory table
- Added integ test for the edge case of 5 deposits of $20, confirming that the interest rate is applied and logged in the transactionHistory table
- Added integ test for the edge case of 5 deposits of $20.01, confirming that the interest rate is applied and logged in the transactionHistory table

python-sql-scripts/addCustomers.py

- Update DB schema for transactionHistory table to allow for interest applications (called 'DepositInterest') to be logged as a transaction

**March 31**
src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
- Added integ test for buying ETH, SOL, and then selling a fraction of their SOL, confirming the amounts are accurate
- Added integ test for unsuccessful purchase of BTC, because BTC is currently not supported
- Added integ test for unsuccessful selling of BTC, because BTC is currently not supported