### PR TITLE
added tests to ensure functionality of crypto frontend

### DIFF
--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1582,4 +1582,104 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
+  /**
+   * Tests the situation in which a customer with no pre-existing Crypto buys 
+   * ETH, buys SOL, and then sells some of their SOL. Does not test overdraft scenarios. 
+   */
+  @Test
+  public void testBuyETHAndSOLSellSOL() throws ScriptException {
+    /* Buy ETH */
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+            cryptoTransactionTester.initialize();
+
+    CryptoTransaction buyETHTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("ETH")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+      
+      cryptoTransactionTester.test(buyETHTransaction);
+
+    /* Buy SOL */
+    CryptoTransaction buySOLTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(800)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+        
+
+    cryptoTransactionTester.test(buySOLTransaction);
+
+    /* Sell SOL */
+    CryptoTransaction sellSOLTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(true)
+            .build();
+
+    cryptoTransactionTester.test(sellSOLTransaction);
+  }
+
+  /**
+   * Ensures that the "welcome" page is returned when a user attempts to put "BTC" 
+   * as the crypto name in the front-end when filling out the CryptoBuy form.
+   */
+  @Test
+  public void testBuyBTC() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(false)
+            .build();
+
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+  /**
+   * Ensures that the "welcome" page is returned when a user attempts to put "BTC" 
+   * as the crypto name in the front-end when filling out the CryptoBuy form.
+   */
+  @Test
+  public void testSellBTC() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+              .initialBalanceInDollars(1000)
+              .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(false)
+            .build();
+            
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
 }


### PR DESCRIPTION
I have implemented 3 additional Solana Integration tests to assess the functionality of the frontend crypto feature. These tests will ensure users are easily able to complete their crypto purchases and sales. 

#### Changes made to `src/test/java/net/testudobank/tests/MvcControllerIntegTest.java`
Added 3 Solana Integration Tests which use the existing `CryptoTransactionTester` class: 

- `testBuyETHAndSOLSellSOL()`: Tests the situation in which a customer with no pre-existing Crypto buys ETH, buys SOL, and then sells some of their SOL, verifying the account balance in dollars and bitcoin. Does not test overdraft scenarios.

- `testBuyBTC()`: Ensures that the "welcome" page is returned when a user attempts to buy "BTC" in the front-end when filling out the CryptoBuy form.

- `testSellBTC()`: Ensures that the "welcome" page is returned when a user attempts to sell "BTC" in the front-end when filling out the CryptoBuy form.