### PR TITLE
Added 3 Integration Tests for the Solana Coin support

### DIFF
--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1582,4 +1582,100 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
+  /**
+   * Test that the Buy ETH, Buy SOL, Sell SOL user flow works
+   */
+  @Test
+  public void testCryptoUserFlow() throws ScriptException {
+    // customer starts with default crypto balance of 0
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    // buy ETH
+    CryptoTransaction cryptoETHTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("ETH")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(cryptoETHTransaction);
+
+    // buy SOL
+    CryptoTransaction cryptoSOLTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(700)
+            .expectedEndingCryptoBalance(0.2)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.2)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(cryptoSOLTransaction);
+
+    // sell SOL
+    CryptoTransaction cryptoSOLTransaction2 = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(800)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(cryptoSOLTransaction2);
+  }
+
+  /**
+   * Test that no transaction occurs when user tries to buy BTC, since TestudoBank 
+   * does not yet support BTC
+   */
+  @Test
+  public void testBuyBTCInvalidCoin() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(false)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+  /**
+   * Test that no transaction occurs when user tries to sell BTC, since TestudoBank 
+   * does not yet support BTC
+   */
+  @Test
+  public void testSellBTCInvalidCoin() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(false)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+
 }
+


### PR DESCRIPTION
Changes Made in this PR:

I have added 3 integration tests that test the user flow for buying and selling ETH and SOL cryptocurrencies and test that invalid transactions are not carried out for BTH, which is not supported by TestudoBank as of now. 

---
`src/test/java/net/testudobank/tests/MvcControllerIntegTest.java`

- Wrote `testCryptoUserFlow()` which checks that user balance and crypto balance are updated correctly and transaction is successful in the case that a user buys ETH, buys SOL, then sells SOL
- Wrote `testBuyBTCInvalidCoin()` which tests that transaction is unsuccessful and user balance is unchanged when user attempts to buy BTC
- Wrote `testSellBTCInvalidCoin()` which tests that transaction is unsuccessful and user balance is unchanged when user attempts to sell BTC