### PR TITLE
Added 3 integration tests for Solona Coin support and BitCoin invalidity

### DIFF
--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1582,4 +1582,102 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
+  /**
+   * Test simple case of user with no pre-existing crypto buying ETH, buying SOL,
+   * then selling some of their SOL
+   */
+  @Test
+  public void testBuyEthBuySolSellSolSimple() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    // Buying .1 ETH
+    CryptoTransaction EthTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("ETH")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(EthTransaction);
+
+    // Buying .1 SOL
+    CryptoTransaction SolTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(800)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(SolTransaction);
+
+    // Selling .1 SOL
+    CryptoTransaction SolSellTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(SolSellTransaction);
+  }
+
+  /**
+   * Test that buying BitCoin will return the user to the "welcome" page because
+   * TestudoBank does not currently support BitCoin
+   */
+  @Test
+  public void testBitCoinBuyInvalid() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    // Attempting to by .1 BTC, should NOT succeed
+    CryptoTransaction BtcTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .expectedEndingCryptoBalance(0)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(false)
+            .build();
+    cryptoTransactionTester.test(BtcTransaction);
+  }
+
+  /**
+   * Test that selling BitCoin will return the user to the "welcome" page because
+   * TestudoBank does not currently support BitCoin
+   */
+  @Test
+  public void testBitCoinSellInvalid() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    // Attempting to sell .1 ETH, should NOT succeed
+    CryptoTransaction BtcSellTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .expectedEndingCryptoBalance(0)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(false)
+            .build();
+    cryptoTransactionTester.test(BtcSellTransaction);
+  }
 }


### PR DESCRIPTION
 **Changes Made in this PR:**

I have added 3 integration tests that will test the simple functionality of buying ETH and SOL, selling SOL, and verifying that buying and selling BitCoin is not supported on TestudoBank.
<hr>

`src/test/java/net/testudobank/tests/MvcControllerIntegTest.java`
- Wrote integration test `testBuyEthBuySolSellSolSimple()` that will verify the functionality of a customer with no pre-existing Crypto buying 0.1 ETH, buying 0.1 SOL, and selling 0.1 SOL.
- Wrote the integration test `testBitCoinBuyInvalid()` that will verify that when a user attempts to put "BTC" as the crypto name in the front-end when filling out the CryptoBuy form the "welcome" page will be returned.
- Wrote the integration test `testBitCoinSellInvalid()` that will verify that when a user attempts to sell BitCoin the "welcome" page will be returned.