### PR TITLE
Adding a crypto interest feature

### DIFF
--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1582,4 +1582,96 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
+  /**
+   * Test when a customer with no pre-existing Crypto buys ETH, buys SOL, and sells their SOL.
+   */
+  @Test
+  public void testCryptoBuyEthBuySolSellUserFlow() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+      .initialBalanceInDollars(1000)
+      .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+      .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction buyEth = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(900)
+      .expectedEndingCryptoBalance(0.1)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("ETH")
+      .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+      .shouldSucceed(true)
+      .build();
+    cryptoTransactionTester.test(buyEth);
+
+    CryptoTransaction buySol = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(800)
+      .expectedEndingCryptoBalance(0.1)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("SOL")
+      .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+      .shouldSucceed(true)
+      .build();
+    cryptoTransactionTester.test(buySol);
+
+    CryptoTransaction sellSol = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(900)
+      .expectedEndingCryptoBalance(0)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("SOL")
+      .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+      .shouldSucceed(true)
+      .build();
+    cryptoTransactionTester.test(sellSol);
+  }
+
+  /**
+   * Test that ensures that the "welcome" page is returned when a user attempts to put "BTC" 
+   * as the crypto name in the front-end when filling out the CryptoBuy form.
+   */
+  @Test
+  public void testCryptoBuyBtcInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+      .initialBalanceInDollars(1000)
+      .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction buyBtc = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(1000)
+      .expectedEndingCryptoBalance(0)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("BTC")
+      .shouldSucceed(false)
+      .build();
+    cryptoTransactionTester.test(buyBtc);
+  }
+
+  /**
+   * Test that ensures that the "welcome" page is returned when a user attempts to put "BTC" 
+   * as the crypto name in the front-end when filling out the CryptoSell form. 
+   */
+  @Test
+  public void testCryptoSellBtcInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+      .initialBalanceInDollars(1000)
+      .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction sellSol = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(1000)
+      .expectedEndingCryptoBalance(0)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("BTC")
+      .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+      .shouldSucceed(false)
+      .build();
+    cryptoTransactionTester.test(sellSol);
+  }
 }


### PR DESCRIPTION
Changes Made in this PR:
I created an interest rate feature that allows users to receive interest (1.5%) on their crypto balance if they continue to buy crypto each month. The feature is an incentive for customers to continue investing in crypto, especially those who are interested to start venturing into cryptocurrency investment. Test cases are included to validate if the feature is used correctly, especially in situations where the customer does not continue monthly payments and therefore does not receive the monthly interest rate.

`src/main/java/net/testudobank/MvcController.java`

- Created the `applyMonthlyCryptoInterest` helper method to add interest rate by checking if the user had crypto buy transaction in the previous month and then adds interest to the user's crypto account for that specific crypto coin.
   - Checks if the customer has previously purchased the crypto coin and if so, what date. If not, will show the welcome page.
   - Uses the helper method `hadCryptoBuyLastMonth` to check whether or not the user had purchased the coin last month.
   - If the user did not purchase the specific crypto last month, then they are returned to the welcome page.
   - If the user did purchase the crypto last month, then the 0.015% of their current balance is calculated and added to their total balance of the specific crypto coin, to further incentives them to continue investing in the coin. 
- Created the `hadCryptoBuyLastMonth` helper method, which uses the current crypto transaction date and the last crypto buy date to figure out whether there was a crypto buy transaction the previous month
   - Uses a string substring to get the month value of the date and compares the date to figure out if the current month is greater that the previous transaction's month (except in the case of December)

`src/test/java/net/testudobank/tests/MvcControllerIntegTest.java`

- Created the unit test to check whether the interest application feature worked.
    - Checks if the interest is added 1 month after the initial crypto buy of a specific coin if the customer does buy the same crypto the next month after the initial crypto buy.
    - Checks if the interest is not added 1 month after the initial crypto buy of a specific coin if the customer does not buy the same crypto the next month after the initial crypto buy.