### PR TITLE
updated ethereum and solana tests to no longer return values less than 0

### DIFF
--- a/src/main/java/net/testudobank/CryptoPriceClient.java
+++ b/src/main/java/net/testudobank/CryptoPriceClient.java
@@ -39,9 +39,11 @@ public class CryptoPriceClient {
     @Cacheable("eth-value")
     public double getCurrentEthValue() {
 
-      int sign = (Math.random() > 0.5) ? 1 : -1;
+      // Generate a positive random number between 0 and 500
+      double randomOffset = Math.random() * 500;
 
-      return 1650 + (sign * Math.random() * 500); 
+      // Always add this positive number to 1650
+      return 1650 + randomOffset;
       
       // try {
       //   // return YahooFinance.get("ETH-USD").getQuote().getPrice().doubleValue();
@@ -66,9 +68,11 @@ public class CryptoPriceClient {
     @Cacheable("sol-value")
     public double getCurrentSolValue() {
       
-      int sign = (Math.random() > 0.5) ? 1 : -1;
+      // Generate a positive random number between 0 and 50
+      double randomOffset = Math.random() * 50;
 
-      return 30 + (sign * Math.random() * 50);
+      // Add this positive number to 30
+      return 30 + randomOffset;
 
       // try {
       //     // return YahooFinance.get("SOL-USD").getQuote().getPrice().doubleValue();


### PR DESCRIPTION
Changed the current tests that resulted in the prices of ethereum and Solana occasionally being negative to always be positive. Simple logic fix, ternary operator was used previously which led to occasional negative values being assigned. Removed the ternary to ensure values are always positive. Continued to use arbitrary values for Solana and ethereum base price.