### PR TITLE
Added Basic SOL Test and Unsupported Crypto Tests

### DIFF
--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1606,13 +1606,6 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
             .build();
     cryptoTransactionTester.test(cryptoTransactionBuyETH);
 
-    // cryptoTransactionTester = CryptoTransactionTester.builder()
-    //         .initialBalanceInDollars(900)
-    //         .initialCryptoBalance(Collections.singletonMap("ETH", 0.1))
-    //         .build();
-
-    // cryptoTransactionTester.initialize();
-
     CryptoTransaction cryptoTransactionBuySOL = CryptoTransaction.builder()
             .expectedEndingBalanceInDollars(890)
             .expectedEndingCryptoBalance(0.1)

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1581,5 +1581,111 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
             .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
+
+   /**
+   * Tests when a customer buys ETH & SOL and sells SOL
+   */
+  @Test
+  public void testCryptoBuyTwoSellOne() throws ScriptException {
+
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransactionBuyETH = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("ETH")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(cryptoTransactionBuyETH);
+
+    // cryptoTransactionTester = CryptoTransactionTester.builder()
+    //         .initialBalanceInDollars(900)
+    //         .initialCryptoBalance(Collections.singletonMap("ETH", 0.1))
+    //         .build();
+
+    // cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransactionBuySOL = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(890)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(100)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+    cryptoTransactionTester.test(cryptoTransactionBuySOL);
+
+    CryptoTransaction cryptoTransactionSellSOL = CryptoTransaction.builder()
+    .expectedEndingBalanceInDollars(910)
+    .expectedEndingCryptoBalance(0.0)
+    .cryptoPrice(200)
+    .cryptoAmountToTransact(0.1)
+    .cryptoName("SOL")
+    .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+    .shouldSucceed(true)
+    .build();
+    cryptoTransactionTester.test(cryptoTransactionSellSOL);
+
+  }
+
+  /*
+   * Tests when a customer tries to buy BTC which is not a valid crypto currency 
+   */
+  @Test
+  public void testCryptoBuyInvalidCurrency() throws ScriptException {
+
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction= CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .expectedEndingCryptoBalance(0.0)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(false)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+  /*
+   * Tests when a customer tries to sell BTC which is not a valid crypto currency
+   */
+  @Test
+  public void testCryptoSellInvalidCurrency() throws ScriptException {
+
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction= CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .expectedEndingCryptoBalance(0.0)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(false)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+  
   
 }


### PR DESCRIPTION
**Changes Made in this PR:**

In this PR added 3 integration tests. The first test involves buying both ETH and SOL and selling SOL. The second and third tests involve the testing of buying and selling BTC, an unsupported cryptocurrency
___

`src/test/java/net/testudobank/tests/MvcControllerIntegTest.java`
1. - The user initially has 1000.00$ balance and no cryptocurrency. 
    - The user buys 0.1 ETH which costs 1000.00$ a coin, reducing balance to 900.00$ and increasing ETH balance to 0.1
    - The user buys 0.1 SOL which costs 100.00$ a coin, reducing balance to 890.00$ and increasing SOL balance to 0.1
     - The user sells 0.1 SOL which costs 200.00$ a coin,increasing balance to 910.00$ and decreasing SOL balance to 0.0
     
2.  - The user initially has 1000.00$ balance and no cryptocurrency. 
     - The user attempts to buy 0.1 BTC which costs 1000.00$ a coin, but since BTC is unsupported, balance and crypto-balance both remain unchanged. The transaction fails and return to the welcome 
3. - The user initially has 1000.00$ balance and no cryptocurrency. 
    - The user attempts to sell 0.1 BTC which costs 1000.00$ a coin, but since BTC is unsupported, balance and crypto-balance both remain unchanged. The transaction fails and return to the welcome 
     
___

**Future changes to make:**
- Add more testing and test different edge cases.






