### PR TITLE
Add Crypto tests for crypto buy/sell flow and for invalid currencies.

### DIFF
--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -379,6 +379,11 @@ public class MvcController {
    * @return "account_info" page if withdraw request is valid. Otherwise, redirect to "welcome" page.
    */
   @PostMapping("/withdraw")
+
+	// Calculates penny interest
+  private int applyInterestRateToPennyAmount(int pennyAmount){
+	  return (int)(pennyAmount * INTEREST_RATE);
+}
   public String submitWithdraw(@ModelAttribute("user") User user) {
     String userID = user.getUsername();
     String userPasswordAttempt = user.getPassword();
@@ -410,7 +415,7 @@ public class MvcController {
     int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
     if (userWithdrawAmtInPennies > userBalanceInPennies) { // if withdraw amount exceeds main balance, withdraw into overdraft with interest fee
       int excessWithdrawAmtInPennies = userWithdrawAmtInPennies - userBalanceInPennies;
-      int newOverdraftIncreaseAmtAfterInterestInPennies = (int)(excessWithdrawAmtInPennies * INTEREST_RATE);
+      int newOverdraftIncreaseAmtAfterInterestInPennies = applyInterestRateToPennyAmount(excessWithdrawAmtInPennies);
       int newOverdraftBalanceInPennies = userOverdraftBalanceInPennies + newOverdraftIncreaseAmtAfterInterestInPennies;
 
       // abort withdraw transaction if new overdraft balance exceeds max overdraft limit

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1581,5 +1581,98 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
             .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
-  
+  /**
+   * Test buying ETH, SOL, then sells SOL
+   */
+  @Test
+  public void testCryptoBuyETHBuySOLSellSOL() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction buyingETHTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(800)
+            .expectedEndingCryptoBalance(0.2)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.2)
+            .cryptoName("ETH")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+
+    cryptoTransactionTester.test(buyingETHTransaction);
+
+    CryptoTransaction buyingSOLTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(700)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+
+    cryptoTransactionTester.test(buyingSOLTransaction);     
+
+    CryptoTransaction sellingSOLTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(800)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(true)
+            .build();
+
+    cryptoTransactionTester.test(sellingSOLTransaction);
+
+  }
+    /**
+   * Test that makes sure buying BTC is false
+   */
+  @Test
+  public void testCryptoBuyBTCInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(false)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+      /**
+   * Test that makes sure selling BTC is false
+   */
+  @Test
+  public void testCryptoSellBTCInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Collections.singletonMap("BTC", 0.1))
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(false)
+            .build();
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
 }


### PR DESCRIPTION
**Changes Made**:

3 tests were added to `MvcControllerIntegTest`:

* Buy ETH, Buy SOL, Sell SOL `testCryptoBuyETHBuySOLSellSOL`
 
  * Test checks if buying ETH, then SOL, and selling SOL is valid.
  * This happen in succession, so all should be work in the same instance
  
* Buy BTC Invalid Case `testCryptoBuyBTCInvalidCase`

  * BTC is not supported by the system at the moment, so the test makes sure that BTC transaction should fail
  
* Sell BTC Invalid Case `testCryptoSellBTCInvalidCase`

  * Same as above case but for the Selling action
 
This was done by utilizing previous methods defined in `CryptoTransactionTester` to construct these.

**Future changes to be made**:

Test will have to be updated when BTC becomes a supported currency. Otherwise it will give a false result for when that gets implemented.