### PR TITLE
Added features for resetting password and security questions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.20</version>
+      <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
 

--- a/python-sql-scripts/addCustomers.py
+++ b/python-sql-scripts/addCustomers.py
@@ -20,7 +20,8 @@ create_customer_table_sql = '''
     Balance int,
     OverdraftBalance int,
     NumFraudReversals int,
-    NumDepositsForInterest int
+    NumDepositsForInterest int,
+    ResetPasswordDay int
   );
   '''
 cursor.execute(create_customer_table_sql)
@@ -29,7 +30,12 @@ cursor.execute(create_customer_table_sql)
 create_password_table_sql = '''
 CREATE TABLE Passwords (
   CustomerID varchar(255),
-  Password varchar(255)
+  Password varchar(255),
+  PasswordAttempts int,
+  SecurityAnswer1 varchar(255),
+  SecurityAnswer2 varchar(255),
+  SecurityAnswer3 varchar(255),
+  NewPasswordForReset varchar(255)
 );
 '''
 cursor.execute(create_password_table_sql)
@@ -129,22 +135,28 @@ for i in range(num_customers_to_add):
     # both the balance and overdraftbalance columns represent the total dollar amount as pennies instead of dollars.
     insert_customer_sql = '''
     INSERT INTO Customers
-    VALUES  ({0},{1},{2},{3},{4},{5}, {6});
+    VALUES  ({0},{1},{2},{3},{4},{5},{6},{7});
     '''.format("'" + customer_id + "'",
                 "'" + customer_first_name + "'",
                 "'" + customer_last_name + "'",
                 customer_balance,
                 0,
                 0,
-                0)
+                0,
+                30)
     cursor.execute(insert_customer_sql)
     
     # add customer ID and password to Passwords table
     insert_password_sql = '''
     INSERT INTO Passwords
-    VALUES  ({0},{1});
+    VALUES  ({0},{1},{2},{3},{4},{5},{6});
     '''.format("'" + customer_id + "'",
-                "'" + customer_password + "'")
+                "'" + customer_password + "'",
+                0,
+                "'n/a'",
+                "'n/a'",
+                "'n/a'",
+                "'n/a new password'")
     cursor.execute(insert_password_sql)
     
     # add this customer's randomly-generated ID to the set

--- a/python-sql-scripts/credentials.py
+++ b/python-sql-scripts/credentials.py
@@ -1,5 +1,5 @@
 # MySQL DB Connection Config Values
 mysql_endpoint='localhost'
 username='root'
-password='<Put MySQL Server Password Here>'
+password='Mysqlrootuser211!'
 database_name = 'testudo_bank'

--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -181,6 +181,7 @@ public class MvcController {
 	}
 
   //// HELPER METHODS ////
+
   /**
    * Helper method that queries the MySQL DB for the customer account info (First Name, Last Name, and Balance)
    * and adds these values to the `user` Model Attribute so that they can be displayed in the "account_info" page.
@@ -250,7 +251,7 @@ public class MvcController {
     return dateTime;
   }
 
-  // Applies interest rate to penny amount
+  // Helper method that applies interest rate to penny amount
   private static int applyInterestRateToPennyAmount(int pennyAmount) {
     return (int) (pennyAmount * INTEREST_RATE);
   }

--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -181,7 +181,6 @@ public class MvcController {
 	}
 
   //// HELPER METHODS ////
-
   /**
    * Helper method that queries the MySQL DB for the customer account info (First Name, Last Name, and Balance)
    * and adds these values to the `user` Model Attribute so that they can be displayed in the "account_info" page.
@@ -249,6 +248,11 @@ public class MvcController {
   private static Date convertLocalDateTimeToDate(LocalDateTime ldt){
     Date dateTime = Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
     return dateTime;
+  }
+
+  // Applies interest rate to penny amount
+  private static int applyInterestRateToPennyAmount(int pennyAmount) {
+    return (int) (pennyAmount * INTEREST_RATE);
   }
 
   // HTML POST HANDLERS ////
@@ -410,7 +414,7 @@ public class MvcController {
     int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
     if (userWithdrawAmtInPennies > userBalanceInPennies) { // if withdraw amount exceeds main balance, withdraw into overdraft with interest fee
       int excessWithdrawAmtInPennies = userWithdrawAmtInPennies - userBalanceInPennies;
-      int newOverdraftIncreaseAmtAfterInterestInPennies = (int)(excessWithdrawAmtInPennies * INTEREST_RATE);
+      int newOverdraftIncreaseAmtAfterInterestInPennies = applyInterestRateToPennyAmount(excessWithdrawAmtInPennies);
       int newOverdraftBalanceInPennies = userOverdraftBalanceInPennies + newOverdraftIncreaseAmtAfterInterestInPennies;
 
       // abort withdraw transaction if new overdraft balance exceeds max overdraft limit

--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -352,7 +352,8 @@ public class MvcController {
     } else { // simple deposit case
       // If deposit amount is >= 20 and no overdraft, then interest can apply
       int numDepositsForInterest = TestudoBankRepository.getCustomerNumberOfDepositsForInterest(jdbcTemplate, userID);
-      if (userDepositAmtInPennies >= MIN_DEPOSIT_AMOUNT_FOR_INTEREST) {
+      int userBalanceInPennies = TestudoBankRepository.getCustomerCashBalanceInPennies(jdbcTemplate, userID); // Fetch balance
+      if (userDepositAmtInPennies >= MIN_DEPOSIT_AMOUNT_FOR_INTEREST && userBalanceInPennies > 0) {
         numDepositsForInterest = numDepositsForInterest + 1;
         TestudoBankRepository.setCustomerNumberOfDepositsForInterest(jdbcTemplate, userID, numDepositsForInterest);
       }

--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -88,6 +88,21 @@ public class MvcController {
 		return "login_form";
 	}
 
+  /**
+   * HTML GET request handler that serves the "login_with_securityquestions" page to the user.
+   * An empty `User` object is also added to the Model as an Attribute to store
+   * the user's login form input.
+   * 
+   * @param model
+   * @return "login_with_securityquestions" page
+   */
+  @GetMapping("/login_with_securityquestions")
+	public String showLoginWithSQForm(Model model) {
+		User user = new User();
+    model.addAttribute("user", user);
+
+		return "login_with_securityquestions";
+	}
 
     /**
    * HTML GET request handler that serves the "securityquestions_form" page to the user.
@@ -323,6 +338,7 @@ public class MvcController {
     String userPassword = TestudoBankRepository.getCustomerPassword(jdbcTemplate, userID);
     int resetPasswordDay = TestudoBankRepository.getResetPasswordDay(jdbcTemplate, userID);
 
+    // If reset is pending, then redirect to Reset Password Form
     if (resetPasswordDay <= 0) {
       return "resetpassword_form";
     } else if (userPasswordAttempt.equals(userPassword)) {
@@ -354,17 +370,17 @@ public class MvcController {
 
 
   /**
-   * HTML POST request handler that uses user input from Login Form page to determine 
+   * HTML POST request handler that uses user input from Login with SQ Form page to determine 
    * login success or failure.
    * 
-   * Queries 'passwords' table in MySQL DB for the correct password associated with the
-   * username ID given by the user. Compares the user's password attempt with the correct
-   * password.
+   * Queries 'passwords' table in MySQL DB for the correct security questions associated with the
+   * username ID given by the user. Compares the user's security answer attempts with the correct
+   * security answers.
    * 
-   * If the password attempt is correct, the "account_info" page is served to the customer
+   * If the security answer attempt is correct, the "account_info" page is served to the customer
    * with all account details retrieved from the MySQL DB.
    * 
-   * If the password attempt is incorrect, the user is redirected to the "welcome" page.
+   * If the security answer attempt is incorrect, the user is redirected to the "welcome" page.
    * 
    * @param user
    * @return "account_info" page if login successful. Otherwise, redirect to "welcome" page.
@@ -384,6 +400,7 @@ public class MvcController {
     String securityAnswer3 = TestudoBankRepository.getSecurityAnswer3(jdbcTemplate, userID);
     int resetPasswordDay = TestudoBankRepository.getResetPasswordDay(jdbcTemplate, userID);
 
+    // If reset is pending, then redirect to Reset Password Form
     if (resetPasswordDay <= 0) {
       return "resetpassword_form";
     } else if (securityAnswer1Attempt.equals(securityAnswer1)
@@ -399,12 +416,14 @@ public class MvcController {
 
 
     /**
-   * HTML POST request handler that uses user input from Login Form page to determine 
-   * login success or failure.
+   * HTML POST request handler that uses user input from Security Question Form page to set
+   * security questions for the user.
    * 
    * Queries 'passwords' table in MySQL DB for the correct password associated with the
    * username ID given by the user. Compares the user's password attempt with the correct
    * password.
+   * 
+   * If the password attempt is correct, set security answers to user input.
    * 
    * If the password attempt is correct, the "account_info" page is served to the customer
    * with all account details retrieved from the MySQL DB.
@@ -443,17 +462,22 @@ public class MvcController {
 
 
   /**
-   * HTML POST request handler that uses user input from Login Form page to determine 
-   * login success or failure.
-   * 
-   * Queries 'passwords' table in MySQL DB for the correct password associated with the
-   * username ID given by the user. Compares the user's password attempt with the correct
+   * HTML POST request handler that uses user input from Reset Password Form page to reset
    * password.
    * 
-   * If the password attempt is correct, the "account_info" page is served to the customer
-   * with all account details retrieved from the MySQL DB.
+   * Queries 'passwords' table in MySQL DB for the correct password and security questions
+   * associated with the username ID given by the user. Compares the user's password attempt
+   * with the correct password or the user's security answer attempts with the correct
+   * security answers.
    * 
-   * If the password attempt is incorrect, the user is redirected to the "welcome" page.
+   * If the password or security answer attempt is correct, the password will be reset with
+   * the new password.
+   * 
+   * If the password or security answer attempt is correct, the "account_info" page is served
+   * to the customer with all account details retrieved from the MySQL DB.
+   * 
+   * If the password or security answer attempt is incorrect, the user is redirected to the
+   * "welcome" page.
    * 
    * @param user
    * @return "account_info" page if login successful. Otherwise, redirect to "welcome" page.

--- a/src/main/java/net/testudobank/TestudoBankRepository.java
+++ b/src/main/java/net/testudobank/TestudoBankRepository.java
@@ -15,6 +15,11 @@ public class TestudoBankRepository {
     return customerPassword;
   }
 
+  public static void setCustomerPassword(JdbcTemplate jdbcTemplate, String customerPassword, String customerID) {
+    String customerPasswordUpdateSql = String.format("UPDATE Passwords SET Password='%s' WHERE CustomerID='%s';", customerPassword, customerID);
+    jdbcTemplate.update(customerPasswordUpdateSql);
+  }
+
   public static int getCustomerNumberOfReversals(JdbcTemplate jdbcTemplate, String customerID) {
     String getNumberOfReversalsSql = String.format("SELECT NumFraudReversals FROM Customers WHERE CustomerID='%s';", customerID);
     int numOfReversals = jdbcTemplate.queryForObject(getNumberOfReversalsSql, Integer.class);
@@ -78,6 +83,72 @@ public class TestudoBankRepository {
     String getCustomerNumberOfDepositsForInterestSql = String.format("SELECT NumDepositsForInterest FROM Customers WHERE CustomerID='%s';", customerID);
     int numberOfDepositsForInterest = jdbcTemplate.queryForObject(getCustomerNumberOfDepositsForInterestSql, Integer.class);
     return numberOfDepositsForInterest;
+  }
+
+  public static String getSecurityAnswer1(JdbcTemplate jdbcTemplate, String customerID) {
+    String getSecurityAnswer1Sql = String.format("SELECT SecurityAnswer1 FROM Passwords WHERE CustomerID='%s';", customerID);
+    String securityAnswer1 = jdbcTemplate.queryForObject(getSecurityAnswer1Sql, String.class);
+    return securityAnswer1;
+  }
+
+  public static String getSecurityAnswer2(JdbcTemplate jdbcTemplate, String customerID) {
+    String getSecurityAnswer2Sql = String.format("SELECT SecurityAnswer2 FROM Passwords WHERE CustomerID='%s';", customerID);
+    String securityAnswer2 = jdbcTemplate.queryForObject(getSecurityAnswer2Sql, String.class);
+    return securityAnswer2;
+  }
+
+  public static String getSecurityAnswer3(JdbcTemplate jdbcTemplate, String customerID) {
+    String getSecurityAnswer3Sql = String.format("SELECT SecurityAnswer3 FROM Passwords WHERE CustomerID='%s';", customerID);
+    String securityAnswer3 = jdbcTemplate.queryForObject(getSecurityAnswer3Sql, String.class);
+    return securityAnswer3;
+  }
+
+  public static void setSecurityAnswer1(JdbcTemplate jdbcTemplate, String securityAnswer1, String customerID) {
+    String securityAnswer1UpdateSql = String.format("UPDATE Passwords SET SecurityAnswer1='%s' WHERE CustomerID='%s';", securityAnswer1, customerID);
+    jdbcTemplate.update(securityAnswer1UpdateSql);
+  }
+
+  public static void setSecurityAnswer2(JdbcTemplate jdbcTemplate, String securityAnswer2, String customerID) {
+    String securityAnswer2UpdateSql = String.format("UPDATE Passwords SET SecurityAnswer2='%s' WHERE CustomerID='%s';", securityAnswer2, customerID);
+    jdbcTemplate.update(securityAnswer2UpdateSql);
+  }
+
+  public static void setSecurityAnswer3(JdbcTemplate jdbcTemplate, String securityAnswer3, String customerID) {
+    String securityAnswer3UpdateSql = String.format("UPDATE Passwords SET SecurityAnswer3='%s' WHERE CustomerID='%s';", securityAnswer3, customerID);
+    jdbcTemplate.update(securityAnswer3UpdateSql);
+  }
+
+  public static int getResetPasswordDay(JdbcTemplate jdbcTemplate, String customerID) {
+    String getResetPasswordDaySql = String.format("SELECT ResetPasswordDay FROM Customers WHERE CustomerID='%s';", customerID);
+    int resetPasswordDay = jdbcTemplate.queryForObject(getResetPasswordDaySql, Integer.class);
+    return resetPasswordDay;
+  }
+
+  public static void setResetPasswordDay(JdbcTemplate jdbcTemplate, int resetPasswordDay, String customerID) {
+    String resetPasswordDayUpdateSql = String.format("UPDATE Customers SET ResetPasswordDay=%d WHERE CustomerID='%s';", resetPasswordDay, customerID);
+    jdbcTemplate.update(resetPasswordDayUpdateSql);
+  }
+
+  public static String getNewPasswordForReset(JdbcTemplate jdbcTemplate, String customerID) {
+    String getnewPasswordForResetSql = String.format("SELECT NewPasswordForReset FROM Passwords WHERE CustomerID='%s';", customerID);
+    String newPasswordForReset = jdbcTemplate.queryForObject(getnewPasswordForResetSql, String.class);
+    return newPasswordForReset;
+  }
+
+  public static void setNewPasswordForReset(JdbcTemplate jdbcTemplate, String newPasswordForReset, String customerID) {
+    String newPasswordForResetUpdateSql = String.format("UPDATE Passwords SET NewPasswordForReset='%s' WHERE CustomerID='%s';", newPasswordForReset, customerID);
+    jdbcTemplate.update(newPasswordForResetUpdateSql);
+  }
+
+  public static int getPasswordAttempts(JdbcTemplate jdbcTemplate, String customerID) {
+    String getPasswordAttemptsSql = String.format("SELECT PasswordAttempts FROM Passwords WHERE CustomerID='%s';", customerID);
+    int passwordAttempts = jdbcTemplate.queryForObject(getPasswordAttemptsSql, Integer.class);
+    return passwordAttempts;
+  }
+
+  public static void setPasswordAttempts(JdbcTemplate jdbcTemplate, int passwordAttempts, String customerID) {
+    String passwordAttemptsUpdateSql = String.format("UPDATE Passwords SET PasswordAttempts=%d WHERE CustomerID='%s';", passwordAttempts, customerID);
+    jdbcTemplate.update(passwordAttemptsUpdateSql);
   }
 
   public static void setCustomerNumberOfDepositsForInterest(JdbcTemplate jdbcTemplate, String customerID, int numDepositsForInterest) { 

--- a/src/main/java/net/testudobank/User.java
+++ b/src/main/java/net/testudobank/User.java
@@ -18,6 +18,24 @@ public class User {
 	private String password;
 
   @Setter @Getter
+	private int passwordAttempts;
+
+  @Setter @Getter @ToString.Include
+	private String securityAnswer1;
+
+  @Setter @Getter @ToString.Include
+	private String securityAnswer2;
+
+  @Setter @Getter @ToString.Include
+	private String securityAnswer3;
+
+  @Setter @Getter @ToString.Include
+	private String newPasswordForReset;
+
+  @Setter @Getter
+	private int resetPasswordDay;
+
+  @Setter @Getter
   private String firstName;
 
   @Setter @Getter

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,4 +2,4 @@ spring.mvc.view.prefix=/WEB-INF/views/
 spring.mvc.view.suffix=.jsp
 spring.datasource.url=jdbc:mysql://localhost:3306/testudo_bank
 spring.datasource.username=root
-spring.datasource.password=<Put MySQL Server Password Here>
+spring.datasource.password=Mysqlrootuser211!

--- a/src/main/webapp/WEB-INF/views/login_with_securityquestions.jsp
+++ b/src/main/webapp/WEB-INF/views/login_with_securityquestions.jsp
@@ -6,7 +6,7 @@
 <head>
   <link rel="icon" href="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png">
   <meta charset="ISO-8859-1">
-  <title>User Login Form</title>
+  <title>User Login Form with Security Questions</title>
   <style type="text/css">
     label {
       display: inline-block;
@@ -51,18 +51,23 @@
 </head>
 <body>
 	<div align="center">
-		<h2>Please sign in: </h2>
-        <img src="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png" style="float:left;width:100px;height:100px;">
-		<form:form action="login" method="post" modelAttribute="user">
+        <h3>Three failed attempts. Please try logging in with your security questions:</h3>
+        <img src="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png" style="float:left;width:130px;height:130px;">
+		<form:form action="login_with_securityquestions" method="post" modelAttribute="user">
 			<form:label path="username">Username:</form:label>
 			<form:input path="username"/><br/>
 			
-			<form:label path="password">Password:</form:label>
-			<form:password path="password"/><br/>		
+            <form:label path="securityAnswer1">Question 1: What was your first car?</form:label>
+			<form:input path="securityAnswer1"/><br/>
+			
+			<form:label path="securityAnswer2">Question 2: What is the name of your first pet?</form:label>
+			<form:input path="securityAnswer2"/><br/>
+            
+            <form:label path="securityAnswer3">Question 3: What is your mother's maiden name?</form:label>
+			<form:input path="securityAnswer3"/><br/>	
 				
 			<form:button>Log in</form:button>
-      <a href='/securityquestions' class="button-link">Add Security Questions</a>
-      <a href='/resetpassword' class="button-link">Reset Password</a>
+            <a href='/resetpassword' class="button-link">Reset Password</a>
 		</form:form>
     <a href='/'>Home</a>
 	</div>

--- a/src/main/webapp/WEB-INF/views/resetpassword_form.jsp
+++ b/src/main/webapp/WEB-INF/views/resetpassword_form.jsp
@@ -1,0 +1,80 @@
+<%@ page language="java" contentType="text/html; charset=ISO-8859-1"
+    pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>    
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="icon" href="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png">
+  <meta charset="ISO-8859-1">
+  <title>Reset Password Form</title>
+  <style type="text/css">
+    label {
+      display: inline-block;
+      width: 200px;
+      margin: 5px;
+      text-align: left;
+    }
+    input[type=text], input[type=password], select {
+      width: 200px;	
+    }
+    input[type=radio] {
+      display: inline-block;
+      margin-left: 45px;
+    }
+    
+    input[type=checkbox] {
+      display: inline-block;
+      margin-right: 190px;
+    }	
+    
+    button {
+      padding: 10px;
+      margin: 10px;
+    }
+    .flex-container {
+      display: flex;
+      justify-content: space-around;
+    }
+    .flex-item {
+      flex: 1;
+      padding: 10px;
+      margin: 10px;
+    }
+   
+  </style>
+</head>
+<body>
+	<div align="center">
+		<h2>Reset Password</h2>
+		<form:form action="resetpassword" method="post" modelAttribute="user">
+            <form:label path="username">Username:</form:label>
+            <form:input path="username"/><br/>
+
+            <div class="flex-container">
+                <div class="flex-item">
+                    <h3>Enter Old Password</h3>
+                    <form:label path="password">Old Password:</form:label>
+                    <form:password path="password"/><br/>	
+                </div>
+                <div class="flex-item">
+                    <h3>Or Answer Security Questions</h3>
+                    <form:label path="securityAnswer1">Question 1: What was your first car?</form:label>
+                    <form:input path="securityAnswer1"/><br/>
+                    
+                    <form:label path="securityAnswer2">Question 2: What is the name of your first pet?</form:label>
+                    <form:input path="securityAnswer2"/><br/>
+                    
+                    <form:label path="securityAnswer3">Question 3: What is your mother's maiden name?</form:label>
+                    <form:input path="securityAnswer3"/><br/>
+                </div>
+            </div>	
+
+            <form:label path="newPasswordForReset">New Password:</form:label>
+            <form:password path="newPasswordForReset"/><br/>
+
+			<form:button>Reset Password</form:button>
+		</form:form>
+    <a href='/'>Home</a>
+	</div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/securityquestions_form.jsp
+++ b/src/main/webapp/WEB-INF/views/securityquestions_form.jsp
@@ -6,7 +6,7 @@
 <head>
   <link rel="icon" href="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png">
   <meta charset="ISO-8859-1">
-  <title>User Login Form</title>
+  <title>Security Questions Form</title>
   <style type="text/css">
     label {
       display: inline-block;
@@ -31,38 +31,29 @@
       padding: 10px;
       margin: 10px;
     }
-    
-    .button-link {
-      display: inline-block;
-      padding: 10px 15px;
-      margin: 10px;
-      background-color: #4CAF50;
-      color: white;
-      text-align: center;
-      text-decoration: none;
-      font-size: 16px;
-      border-radius: 5px;
-    }
-    .button-link:hover {
-      background-color: #45a049;
-    }
    
   </style>
 </head>
 <body>
 	<div align="center">
-		<h2>Please sign in: </h2>
-        <img src="https://fanapeel.com/wp-content/uploads/logo_-university-of-maryland-terrapins-testudo-turtle-hold-red-white-m.png" style="float:left;width:100px;height:100px;">
-		<form:form action="login" method="post" modelAttribute="user">
-			<form:label path="username">Username:</form:label>
+		<h2>Security Questions</h2>
+		<form:form action="securityquestions" method="post" modelAttribute="user">
+            <form:label path="username">Username:</form:label>
 			<form:input path="username"/><br/>
 			
 			<form:label path="password">Password:</form:label>
 			<form:password path="password"/><br/>		
+            
+			<form:label path="securityAnswer1">Question 1: What was your first car?</form:label>
+			<form:input path="securityAnswer1"/><br/>
+			
+			<form:label path="securityAnswer2">Question 2: What is the name of your first pet?</form:label>
+			<form:input path="securityAnswer2"/><br/>
+            
+            <form:label path="securityAnswer3">Question 3: What is your mother's maiden name?</form:label>
+			<form:input path="securityAnswer3"/><br/>
 				
-			<form:button>Log in</form:button>
-      <a href='/securityquestions' class="button-link">Add Security Questions</a>
-      <a href='/resetpassword' class="button-link">Reset Password</a>
+			<form:button>Submit Security Question Answers</form:button>
 		</form:form>
     <a href='/'>Home</a>
 	</div>

--- a/src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java
+++ b/src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java
@@ -33,17 +33,17 @@ public class MvcControllerIntegTestHelpers {
   }
 
   // Uses given customer details to initialize the customer in the Customers and Passwords table in the MySQL DB.
-  public static void addCustomerToDB(DatabaseDelegate dbDelegate, String ID, String password, String firstName, String lastName, int balance, int overdraftBalance, int numFraudReversals, int numInterestDeposits) throws ScriptException {
-    String insertCustomerSql = String.format("INSERT INTO Customers VALUES ('%s', '%s', '%s', %d, %d, %d, %d)", ID, firstName, lastName, balance, overdraftBalance, numFraudReversals, numInterestDeposits);
+  public static void addCustomerToDB(DatabaseDelegate dbDelegate, String ID, String password, int passwordAttempts, String securityAnswer, String firstName, String lastName, int balance, int overdraftBalance, int numFraudReversals, int numInterestDeposits, int resetPasswordDay, String newPasswordForReset) throws ScriptException {
+    String insertCustomerSql = String.format("INSERT INTO Customers VALUES ('%s', '%s', '%s', %d, %d, %d, %d, %d)", ID, firstName, lastName, balance, overdraftBalance, numFraudReversals, numInterestDeposits, resetPasswordDay);
     ScriptUtils.executeDatabaseScript(dbDelegate, null, insertCustomerSql);
 
-    String insertCustomerPasswordSql = String.format("INSERT INTO Passwords VALUES ('%s', '%s')", ID, password);
+    String insertCustomerPasswordSql = String.format("INSERT INTO Passwords VALUES ('%s', '%s', %d, '%s', '%s', '%s', '%s')", ID, password, passwordAttempts, securityAnswer, securityAnswer, securityAnswer, newPasswordForReset);
     ScriptUtils.executeDatabaseScript(dbDelegate, null, insertCustomerPasswordSql);
   }
 
   // Adds a customer to the MySQL DB with no overdraft balance or fraud disputes
-  public static void addCustomerToDB(DatabaseDelegate dbDelegate, String ID, String password, String firstName, String lastName, int balance, int interestDeposits) throws ScriptException {
-    addCustomerToDB(dbDelegate, ID, password, firstName, lastName, balance, 0, 0, 0);
+  public static void addCustomerToDB(DatabaseDelegate dbDelegate, String ID, String password, int passwordAttempts, String securityAnswer, String firstName, String lastName, int balance, int interestDeposits, int resetPasswordDay, String newPasswordForReset) throws ScriptException {
+    addCustomerToDB(dbDelegate, ID, password, passwordAttempts, securityAnswer, firstName, lastName, balance, 0, 0, 0, resetPasswordDay, newPasswordForReset);
   }
 
   // Set crypto balance to specified amount

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -198,6 +198,128 @@ public class MvcControllerIntegTest {
   }
 
   /**
+   * Verifies that interest is applied after every 5th deposit transaction of at least $20
+   * 
+   * The deposits and interest should be recorded in the TransactionHistory table.
+   * 
+   * A few Assertions are omitted to remove clutter since they are already
+   * checked in detail in testSimpleWithdraw().
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testInterestOnDeposits() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    double CUSTOMER1_OVERDRAFT_BALANCE = 0;
+    int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
+    int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
+
+    // Prepare Deposit Form to Deposit several amounts to customer 1's account.
+    double[] CUSTOMER1_AMOUNTS_TO_DEPOSIT = {21.34, 90, 20.00, 20.01, 109.8, 21, 53.5, 21.35, 80}; // user input is in dollar amount, not pennies.
+    User customer1DepositFormInputs = new User();
+    int numOfTransactions = 0;
+
+    for (int i = 0; i < CUSTOMER1_AMOUNTS_TO_DEPOSIT.length; i++) {
+      customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
+      customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
+      customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNTS_TO_DEPOSIT[i]);
+
+      // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory table later
+      LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+      System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
+
+      // send request to the Deposit Form's POST handler in MvcController
+      controller.submitDeposit(customer1DepositFormInputs);
+
+      // fetch updated data from the DB
+      List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    
+      // update customer balance and numOfTransactions
+      Map<String,Object> customer1Data = customersTableData.get(0);
+      CUSTOMER1_BALANCE += CUSTOMER1_AMOUNTS_TO_DEPOSIT[i];
+      numOfTransactions += 1;
+
+      // check that interest is applied after 5 deposits
+      double INTEREST_AMOUNT = 0;
+      if ((i+1) % 5 == 0) {
+        INTEREST_AMOUNT = CUSTOMER1_BALANCE * 0.015; // 1.5% APY
+        CUSTOMER1_BALANCE += INTEREST_AMOUNT;
+
+        numOfTransactions += 1; // increase transaction amount by 1 for interest applied
+      }
+      
+      // Verify that balance is accurate after Deposits
+      assertEquals(MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE), (int)customer1Data.get("Balance"));
+
+      // Verify that NumDepositsForInterest variable is udpated
+      assertEquals((i+1) % 5, (int)customer1Data.get("NumDepositsForInterest"));
+    }
+
+    // Verify that all Deposits and Interest applications were logged in TransactionHistory table
+    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
+    assertEquals(numOfTransactions, transactionHistoryTableData.size());
+  }
+
+    /**
+   * Verifies that interest is not applied for deposits under $20
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testNoInterestOnDeposits() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    double CUSTOMER1_OVERDRAFT_BALANCE = 0;
+    int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
+    int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
+
+    // Prepare Deposit Form to Deposit several amounts to customer 1's account.
+    double[] CUSTOMER1_AMOUNTS_TO_DEPOSIT = {21.34, 90, 20.01, 43.02, 19.9}; // user input is in dollar amount, not pennies.
+    User customer1DepositFormInputs = new User();
+    int numOfTransactions = 0;
+
+    for (int i = 0; i < CUSTOMER1_AMOUNTS_TO_DEPOSIT.length; i++) {
+      customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
+      customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
+      customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNTS_TO_DEPOSIT[i]);
+
+      // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory table later
+      LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+      System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
+
+      // send request to the Deposit Form's POST handler in MvcController
+      controller.submitDeposit(customer1DepositFormInputs);
+
+      // fetch updated data from the DB
+      List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+
+      // update customer balance and numOfTransactions
+      Map<String,Object> customer1Data = customersTableData.get(0);
+      CUSTOMER1_BALANCE += CUSTOMER1_AMOUNTS_TO_DEPOSIT[i];
+      numOfTransactions += 1;
+      
+      // Verify that balance is accurate after Deposits
+      assertEquals(MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE), (int)customer1Data.get("Balance"));
+
+      if (i == CUSTOMER1_AMOUNTS_TO_DEPOSIT.length - 1) {
+        // Verify that NumDepositsForInterest variable has value of 4 for 4 deposits of at least $20
+        assertEquals(4, (int)customer1Data.get("NumDepositsForInterest"));
+      }
+    }
+
+    // Verify that all Deposits were logged in TransactionHistory table
+    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
+    assertEquals(numOfTransactions, transactionHistoryTableData.size());
+  }
+
+  /**
    * Verifies the case where a customer withdraws more than their available balance.
    * The customer's main balance should be set to $0, and their Overdraft balance
    * should be the remaining withdraw amount with interest applied.

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1703,5 +1703,102 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
             .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
+
+  /**
+   * Test where customer buys ETH, buys SOL, and then sells SOL successfully
+   */
+  @Test
+  public void testBuyETHBuySOLSellSOLUserFlow() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Map.of("ETH", 0.1, "SOL", 0.0))
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransactionBuyETH = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0.2)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("ETH")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+
+    cryptoTransactionTester.test(cryptoTransactionBuyETH);
+
+    CryptoTransaction cryptoTransactionBuySOL = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(800)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(true)
+            .build();
+
+    cryptoTransactionTester.test(cryptoTransactionBuySOL);
+
+    CryptoTransaction cryptoTransactionSellSOL = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(900)
+            .expectedEndingCryptoBalance(0.0)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("SOL")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(true)
+            .build();
+
+    cryptoTransactionTester.test(cryptoTransactionSellSOL);
+  }
+
+  /**
+   * Test that no buy transaction occurs when the cryptocurrency name is BTC
+   */
+  @Test
+  public void testBTCBuyInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+            .shouldSucceed(false)
+            .build();
+
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+  /**
+   * Test that no sell transaction occurs when the cryptocurrency name is BTC
+   */
+  @Test
+  public void testBTCSellInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+            .initialBalanceInDollars(1000)
+            .initialCryptoBalance(Collections.singletonMap("BTC", 0.1))
+            .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
+            .expectedEndingBalanceInDollars(1000)
+            .expectedEndingCryptoBalance(0.1)
+            .cryptoPrice(1000)
+            .cryptoAmountToTransact(0.1)
+            .cryptoName("BTC")
+            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+            .shouldSucceed(false)
+            .build();
+
+    cryptoTransactionTester.test(cryptoTransaction);
+  }
   
 }

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1711,14 +1711,14 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
   public void testBuyETHBuySOLSellSOLUserFlow() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
             .initialBalanceInDollars(1000)
-            .initialCryptoBalance(Map.of("ETH", 0.1, "SOL", 0.0))
+            .initialCryptoBalance(Map.of("ETH", 0.0, "SOL", 0.0))
             .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransactionBuyETH = CryptoTransaction.builder()
             .expectedEndingBalanceInDollars(900)
-            .expectedEndingCryptoBalance(0.2)
+            .expectedEndingCryptoBalance(0.1)
             .cryptoPrice(1000)
             .cryptoAmountToTransact(0.1)
             .cryptoName("ETH")

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -230,7 +230,7 @@ public class MvcControllerIntegTest {
     // send request to the Reset Password Form's POST handler in MvcController
     controller.submitResetPasswordForm(passwordResetFormInputs);
 
-    // fetch updated data from the DB;
+    // fetch updated data from the DB
     String actualNewPassword = jdbcTemplate.queryForObject("SELECT Password FROM Passwords WHERE CustomerID=?", String.class, CUSTOMER1_ID);
   
     // verify that the new password is updated in Passwords table
@@ -251,7 +251,7 @@ public class MvcControllerIntegTest {
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
-    // User inputs for password reset
+    // User inputs for security questions
     String securityAnswer1actual = "Toyota";
     String securityAnswer2actual = "Rover";
     String securityAnswer3actual = "Mary";
@@ -262,13 +262,13 @@ public class MvcControllerIntegTest {
     securityQuestionFormInputs.setSecurityAnswer2(securityAnswer2actual); 
     securityQuestionFormInputs.setSecurityAnswer3(securityAnswer3actual); 
 
-    // send request to the Reset Password Form's POST handler in MvcController
+    // send request to the Security Question Form's POST handler in MvcController
     controller.submitSecurityQuestionsForm(securityQuestionFormInputs);
 
-    // fetch updated data from the DB;
+    // fetch updated data from the DB
     List<Map<String, Object>> actualSecurityAnswers = jdbcTemplate.queryForList("SELECT SecurityAnswer1, SecurityAnswer2, SecurityAnswer3 FROM Passwords WHERE CustomerID=?", CUSTOMER1_ID);
   
-    // verify that the new password is updated in Passwords table
+    // verify that the security question answers is updated in Passwords table
     Map<String, Object> answers = actualSecurityAnswers.get(0);
     assertEquals(securityAnswer1actual, answers.get("SecurityAnswer1"));
     assertEquals(securityAnswer2actual, answers.get("SecurityAnswer2"));
@@ -348,13 +348,14 @@ public class MvcControllerIntegTest {
     passwordResetSQFormInputs.setNewPasswordForReset(new_customer_password); 
 
     // send request to the Reset Password Form's POST handler in MvcController
+    // verify that it is redirected to welcome page
     String response = controller.submitResetPasswordForm(passwordResetSQFormInputs);
     assertEquals("welcome", response);
 
     // fetch updated data from the DB;
     String samePassword = jdbcTemplate.queryForObject("SELECT Password FROM Passwords WHERE CustomerID=?", String.class, CUSTOMER1_ID);
   
-    // verify that the new password is updated in Passwords table
+    // verify that the password is not updated in Passwords table
     assertEquals(CUSTOMER1_PASSWORD, samePassword);
   }
 
@@ -380,15 +381,13 @@ public class MvcControllerIntegTest {
     TestudoBankRepository.setSecurityAnswer2(jdbcTemplate, securityAnswer2actual, CUSTOMER1_ID);
     TestudoBankRepository.setSecurityAnswer3(jdbcTemplate, securityAnswer3actual, CUSTOMER1_ID);
 
-    // User inputs for password reset
+    // User inputs for login with SQ
     User passwordResetSQFormInputs = new User();
     passwordResetSQFormInputs.setUsername(CUSTOMER1_ID);
     passwordResetSQFormInputs.setPassword(wrongPassword);
     passwordResetSQFormInputs.setSecurityAnswer1(securityAnswer1actual);
     passwordResetSQFormInputs.setSecurityAnswer2(securityAnswer2actual); 
     passwordResetSQFormInputs.setSecurityAnswer3(securityAnswer3actual);
-
-    System.out.println("here:" + passwordResetSQFormInputs);
 
     // send 3 requests to the Login Form's POST handler in MvcController
     String responsePage = controller.submitLoginForm(passwordResetSQFormInputs);
@@ -399,7 +398,6 @@ public class MvcControllerIntegTest {
     assertEquals("login_with_securityquestions", responsePage);
 
     // send 1 request to the Login with SQ Form's POST handler in MvcController
-    System.out.println("here:" + passwordResetSQFormInputs);
     responsePage = controller.submitLoginSQForm(passwordResetSQFormInputs);
     assertEquals("account_info", responsePage);
   }
@@ -434,8 +432,6 @@ public class MvcControllerIntegTest {
     passwordResetSQFormInputs.setSecurityAnswer2(securityAnswer2actual); 
     passwordResetSQFormInputs.setSecurityAnswer3("wrong");
 
-    System.out.println("here:" + passwordResetSQFormInputs);
-
     // send 3 requests to the Login Form's POST handler in MvcController
     String responsePage = controller.submitLoginForm(passwordResetSQFormInputs);
     assertEquals("login", responsePage);
@@ -445,7 +441,7 @@ public class MvcControllerIntegTest {
     assertEquals("login_with_securityquestions", responsePage);
 
     // send 1 request to the Login with SQ Form's POST handler in MvcController
-    System.out.println("here:" + passwordResetSQFormInputs);
+    // verify that it redirects to welcome page
     responsePage = controller.submitLoginSQForm(passwordResetSQFormInputs);
     assertEquals("welcome", responsePage);
   }

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1,5 +1,6 @@
 package net.testudobank.tests;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 import javax.script.ScriptException;
 
@@ -30,6 +32,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import net.testudobank.MvcController;
+import net.testudobank.TestudoBankRepository;
 import net.testudobank.User;
 import net.testudobank.helpers.MvcControllerIntegTestHelpers;
 
@@ -47,6 +50,11 @@ public class MvcControllerIntegTest {
   private static String CUSTOMER2_PASSWORD = "password";
   private static String CUSTOMER2_FIRST_NAME = "Foo1";
   private static String CUSTOMER2_LAST_NAME = "Bar1";
+
+  private static String CUSTOMER_SECURITY_ANSWER = "n/a";
+  private static String CUSTOMER_NEW_PASSWORD_FOR_RESET = "n/a new password";
+  private static int CUSTOMER_RESET_PASSWORD_DAY = 30;
+  private static int PASSWORD_ATTEMPTS = 0;
   
   // Spins up small MySQL DB in local Docker container
   @Container
@@ -96,7 +104,7 @@ public class MvcControllerIntegTest {
     // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Deposit Form to Deposit $12.34 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 12.34; // user input is in dollar amount, not pennies.
@@ -155,7 +163,7 @@ public class MvcControllerIntegTest {
     // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Withdraw Form to Withdraw $12.34 from customer 1's account.
     double CUSTOMER1_AMOUNT_TO_WITHDRAW = 12.34; // user input is in dollar amount, not pennies.
@@ -198,6 +206,275 @@ public class MvcControllerIntegTest {
   }
 
   /**
+   * Verifies that user successfully resets password.
+   * The customer's Password in the Password table should be reset.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testSuccessfulPasswordReset() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    String CUSTOMER1_PASSWORD = "old_password_123";
+    String new_customer_password = "new_password_123";
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
+
+    // User inputs for password reset
+    User passwordResetFormInputs = new User();
+    passwordResetFormInputs.setUsername(CUSTOMER1_ID);
+    passwordResetFormInputs.setPassword(CUSTOMER1_PASSWORD);
+    passwordResetFormInputs.setNewPasswordForReset(new_customer_password); 
+
+    // send request to the Reset Password Form's POST handler in MvcController
+    controller.submitResetPasswordForm(passwordResetFormInputs);
+
+    // fetch updated data from the DB;
+    String actualNewPassword = jdbcTemplate.queryForObject("SELECT Password FROM Passwords WHERE CustomerID=?", String.class, CUSTOMER1_ID);
+  
+    // verify that the new password is updated in Passwords table
+    assertEquals(new_customer_password, actualNewPassword);
+  }
+
+  /**
+   * Verifies that user successfully sets security questions.
+   * The customer's SecurityAnswer1, SecurityAnswer2, and SecurityAnswer3 in the Password table should be set.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testSetSecurityQuestions() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
+
+    // User inputs for password reset
+    String securityAnswer1actual = "Toyota";
+    String securityAnswer2actual = "Rover";
+    String securityAnswer3actual = "Mary";
+    User securityQuestionFormInputs = new User();
+    securityQuestionFormInputs.setUsername(CUSTOMER1_ID);
+    securityQuestionFormInputs.setPassword(CUSTOMER1_PASSWORD);
+    securityQuestionFormInputs.setSecurityAnswer1(securityAnswer1actual);
+    securityQuestionFormInputs.setSecurityAnswer2(securityAnswer2actual); 
+    securityQuestionFormInputs.setSecurityAnswer3(securityAnswer3actual); 
+
+    // send request to the Reset Password Form's POST handler in MvcController
+    controller.submitSecurityQuestionsForm(securityQuestionFormInputs);
+
+    // fetch updated data from the DB;
+    List<Map<String, Object>> actualSecurityAnswers = jdbcTemplate.queryForList("SELECT SecurityAnswer1, SecurityAnswer2, SecurityAnswer3 FROM Passwords WHERE CustomerID=?", CUSTOMER1_ID);
+  
+    // verify that the new password is updated in Passwords table
+    Map<String, Object> answers = actualSecurityAnswers.get(0);
+    assertEquals(securityAnswer1actual, answers.get("SecurityAnswer1"));
+    assertEquals(securityAnswer2actual, answers.get("SecurityAnswer2"));
+    assertEquals(securityAnswer3actual, answers.get("SecurityAnswer3"));
+  }
+
+  /**
+   * Verifies that user successfully resets password with security questions.
+   * The customer's Password in the Password table should be reset.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testPasswordResetWithSecurityQuestions() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    String CUSTOMER1_PASSWORD = "old_password_123";
+    String new_customer_password = "new_password_123";
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
+    String securityAnswer1actual = "Toyota";
+    String securityAnswer2actual = "Rover";
+    String securityAnswer3actual = "Mary";
+    TestudoBankRepository.setSecurityAnswer1(jdbcTemplate, securityAnswer1actual, CUSTOMER1_ID);
+    TestudoBankRepository.setSecurityAnswer2(jdbcTemplate, securityAnswer2actual, CUSTOMER1_ID);
+    TestudoBankRepository.setSecurityAnswer3(jdbcTemplate, securityAnswer3actual, CUSTOMER1_ID);
+
+    // User inputs for password reset
+    User passwordResetSQFormInputs = new User();
+    passwordResetSQFormInputs.setUsername(CUSTOMER1_ID);
+    passwordResetSQFormInputs.setPassword("some_password");
+    passwordResetSQFormInputs.setSecurityAnswer1(securityAnswer1actual);
+    passwordResetSQFormInputs.setSecurityAnswer2(securityAnswer2actual); 
+    passwordResetSQFormInputs.setSecurityAnswer3(securityAnswer3actual); 
+    passwordResetSQFormInputs.setNewPasswordForReset(new_customer_password); 
+
+    // send request to the Reset Password Form's POST handler in MvcController
+    controller.submitResetPasswordForm(passwordResetSQFormInputs);
+
+    // fetch updated data from the DB;
+    String actualNewPassword = jdbcTemplate.queryForObject("SELECT Password FROM Passwords WHERE CustomerID=?", String.class, CUSTOMER1_ID);
+  
+    // verify that the new password is updated in Passwords table
+    assertEquals(new_customer_password, actualNewPassword);
+  }
+
+  /**
+   * Verifies that user cannot reset password with incorrect security question answers.
+   * The customer's Password in the Password table should not be reset.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testPasswordResetWithIncorrectSecurityQuestions() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    String CUSTOMER1_PASSWORD = "old_password_123";
+    String new_customer_password = "new_password_123";
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
+    String securityAnswer1actual = "Toyota";
+    String securityAnswer2actual = "Rover";
+    String securityAnswer3actual = "Mary";
+    TestudoBankRepository.setSecurityAnswer1(jdbcTemplate, securityAnswer1actual, CUSTOMER1_ID);
+    TestudoBankRepository.setSecurityAnswer2(jdbcTemplate, securityAnswer2actual, CUSTOMER1_ID);
+    TestudoBankRepository.setSecurityAnswer3(jdbcTemplate, securityAnswer3actual, CUSTOMER1_ID);
+
+    // User inputs for password reset
+    User passwordResetSQFormInputs = new User();
+    passwordResetSQFormInputs.setUsername(CUSTOMER1_ID);
+    passwordResetSQFormInputs.setPassword("some_password");
+    passwordResetSQFormInputs.setSecurityAnswer1(securityAnswer1actual);
+    passwordResetSQFormInputs.setSecurityAnswer2(securityAnswer2actual); 
+    passwordResetSQFormInputs.setSecurityAnswer3("wrong"); 
+    passwordResetSQFormInputs.setNewPasswordForReset(new_customer_password); 
+
+    // send request to the Reset Password Form's POST handler in MvcController
+    String response = controller.submitResetPasswordForm(passwordResetSQFormInputs);
+    assertEquals("welcome", response);
+
+    // fetch updated data from the DB;
+    String samePassword = jdbcTemplate.queryForObject("SELECT Password FROM Passwords WHERE CustomerID=?", String.class, CUSTOMER1_ID);
+  
+    // verify that the new password is updated in Passwords table
+    assertEquals(CUSTOMER1_PASSWORD, samePassword);
+  }
+
+  /**
+   * Verifies that user is asked for security questions after 3 failed attempts for login
+   * password input.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testSecurityQuestionsAfterFailedLogins() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    String CUSTOMER1_PASSWORD = "old_password_123";
+    String wrongPassword = "a_wrong_password";
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
+    String securityAnswer1actual = "Toyota";
+    String securityAnswer2actual = "Rover";
+    String securityAnswer3actual = "Mary";
+    TestudoBankRepository.setSecurityAnswer1(jdbcTemplate, securityAnswer1actual, CUSTOMER1_ID);
+    TestudoBankRepository.setSecurityAnswer2(jdbcTemplate, securityAnswer2actual, CUSTOMER1_ID);
+    TestudoBankRepository.setSecurityAnswer3(jdbcTemplate, securityAnswer3actual, CUSTOMER1_ID);
+
+    // User inputs for password reset
+    User passwordResetSQFormInputs = new User();
+    passwordResetSQFormInputs.setUsername(CUSTOMER1_ID);
+    passwordResetSQFormInputs.setPassword(wrongPassword);
+    passwordResetSQFormInputs.setSecurityAnswer1(securityAnswer1actual);
+    passwordResetSQFormInputs.setSecurityAnswer2(securityAnswer2actual); 
+    passwordResetSQFormInputs.setSecurityAnswer3(securityAnswer3actual);
+
+    System.out.println("here:" + passwordResetSQFormInputs);
+
+    // send 3 requests to the Login Form's POST handler in MvcController
+    String responsePage = controller.submitLoginForm(passwordResetSQFormInputs);
+    assertEquals("login", responsePage);
+    responsePage = controller.submitLoginForm(passwordResetSQFormInputs);
+    assertEquals("login", responsePage);
+    responsePage = controller.submitLoginForm(passwordResetSQFormInputs);
+    assertEquals("login_with_securityquestions", responsePage);
+
+    // send 1 request to the Login with SQ Form's POST handler in MvcController
+    System.out.println("here:" + passwordResetSQFormInputs);
+    responsePage = controller.submitLoginSQForm(passwordResetSQFormInputs);
+    assertEquals("account_info", responsePage);
+  }
+
+  /**
+   * Verifies that user is redirected to welcome page after inputting wrong security
+   * question answers after 3 failed attempts for login password input.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testIncorrectSecurityQuestionsAfterFailedLogins() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    String CUSTOMER1_PASSWORD = "old_password_123";
+    String wrongPassword = "a_wrong_password";
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
+    String securityAnswer1actual = "Toyota";
+    String securityAnswer2actual = "Rover";
+    String securityAnswer3actual = "Mary";
+    TestudoBankRepository.setSecurityAnswer1(jdbcTemplate, securityAnswer1actual, CUSTOMER1_ID);
+    TestudoBankRepository.setSecurityAnswer2(jdbcTemplate, securityAnswer2actual, CUSTOMER1_ID);
+    TestudoBankRepository.setSecurityAnswer3(jdbcTemplate, securityAnswer3actual, CUSTOMER1_ID);
+
+    // User inputs for password reset
+    User passwordResetSQFormInputs = new User();
+    passwordResetSQFormInputs.setUsername(CUSTOMER1_ID);
+    passwordResetSQFormInputs.setPassword(wrongPassword);
+    passwordResetSQFormInputs.setSecurityAnswer1(securityAnswer1actual);
+    passwordResetSQFormInputs.setSecurityAnswer2(securityAnswer2actual); 
+    passwordResetSQFormInputs.setSecurityAnswer3("wrong");
+
+    System.out.println("here:" + passwordResetSQFormInputs);
+
+    // send 3 requests to the Login Form's POST handler in MvcController
+    String responsePage = controller.submitLoginForm(passwordResetSQFormInputs);
+    assertEquals("login", responsePage);
+    responsePage = controller.submitLoginForm(passwordResetSQFormInputs);
+    assertEquals("login", responsePage);
+    responsePage = controller.submitLoginForm(passwordResetSQFormInputs);
+    assertEquals("login_with_securityquestions", responsePage);
+
+    // send 1 request to the Login with SQ Form's POST handler in MvcController
+    System.out.println("here:" + passwordResetSQFormInputs);
+    responsePage = controller.submitLoginSQForm(passwordResetSQFormInputs);
+    assertEquals("welcome", responsePage);
+  }
+
+  /**
+   * Verifies that user is directed to Reset Password form if days left to reset password is 0.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testRedirectResetPasswordIfScheduled() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    int CUSTOMER_RESET_PASSWORD_DAY_0 = 0;
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY_0, CUSTOMER_NEW_PASSWORD_FOR_RESET);
+
+    // User inputs for redirect to password reset
+    User redirectResetPasswordFormInputs = new User();
+    redirectResetPasswordFormInputs.setUsername(CUSTOMER1_ID);
+    redirectResetPasswordFormInputs.setPassword(CUSTOMER1_PASSWORD);
+
+    // send request to the Login Form's POST handler in MvcController
+    String response = controller.submitLoginForm(redirectResetPasswordFormInputs);
+    assertEquals("resetpassword_form", response);
+  }
+
+  /**
    * Verifies that interest is applied after every 5th deposit transaction of at least $20
    * 
    * The deposits and interest should be recorded in the TransactionHistory table.
@@ -216,7 +493,7 @@ public class MvcControllerIntegTest {
     double CUSTOMER1_OVERDRAFT_BALANCE = 0;
     int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Deposit Form to Deposit several amounts to customer 1's account.
     double[] CUSTOMER1_AMOUNTS_TO_DEPOSIT = {21.34, 90, 20.00, 20.01, 109.8, 21, 53.5, 21.35, 80}; // user input is in dollar amount, not pennies.
@@ -278,7 +555,7 @@ public class MvcControllerIntegTest {
     double CUSTOMER1_OVERDRAFT_BALANCE = 0;
     int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Deposit Form to Deposit several amounts to customer 1's account.
     double[] CUSTOMER1_AMOUNTS_TO_DEPOSIT = {21.34, 90, 20.01, 43.02, 19.9}; // user input is in dollar amount, not pennies.
@@ -337,7 +614,7 @@ public class MvcControllerIntegTest {
     // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Withdraw Form to Withdraw $150 from customer 1's account.
     double CUSTOMER1_AMOUNT_TO_WITHDRAW = 150; // user input is in dollar amount, not pennies.
@@ -392,7 +669,7 @@ public class MvcControllerIntegTest {
     //initialize customer1 with a balance of $100. this will be represented as pennies in DB.
     double CUSTOMER1_BALANCE = 100;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     //Prepare Withdraw Form to withdraw $1099 from this customer's account.
     double CUSTOMER1_AMOUNT_TO_WITHDRAW = 1099; 
@@ -448,7 +725,7 @@ public class MvcControllerIntegTest {
     double CUSTOMER1_OVERDRAFT_BALANCE = 123.45;
     int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Deposit Form to Deposit $150 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 150; // user input is in dollar amount, not pennies.
@@ -511,7 +788,7 @@ public class MvcControllerIntegTest {
     double CUSTOMER1_OVERDRAFT_BALANCE = 123.45;
     int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Deposit Form to Deposit $50 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 50; // user input is in dollar amount, not pennies.
@@ -576,7 +853,7 @@ public class MvcControllerIntegTest {
     // No overdraft or numFraudReversals.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Deposit Form to Deposit $12.34 (to make sure this works for non-whole dollar amounts) to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 12.34; // user input is in dollar amount, not pennies.
@@ -663,7 +940,7 @@ public class MvcControllerIntegTest {
     // No overdraft or numFraudReversals.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Withdraw Form to Withdraw $12.34 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_WITHDRAW = 12.34; // user input is in dollar amount, not pennies.
@@ -753,12 +1030,16 @@ public class MvcControllerIntegTest {
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, 
                                                   CUSTOMER1_ID, 
                                                   CUSTOMER1_PASSWORD, 
+                                                  PASSWORD_ATTEMPTS,
+                                                  CUSTOMER_SECURITY_ANSWER,
                                                   CUSTOMER1_FIRST_NAME, 
                                                   CUSTOMER1_LAST_NAME, 
                                                   CUSTOMER1_MAIN_BALANCE_IN_PENNIES, 
                                                   CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES,
                                                   CUSTOMER1_NUM_FRAUD_REVERSALS,
-                                                  CUSTOMER1_NUM_INTEREST_DEPOSITS);
+                                                  CUSTOMER1_NUM_INTEREST_DEPOSITS,
+                                                  CUSTOMER_RESET_PASSWORD_DAY,
+                                                  CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Deposit $50, and then immediately dispute/reverse that deposit.
     // this will bring the customer to the MAX_DISPUTES limit, and also have a few
@@ -861,7 +1142,7 @@ public class MvcControllerIntegTest {
     // No overdraft or numFraudReversals.
     double CUSTOMER1_BALANCE = 0;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Deposit Form to Deposit $100 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 100; // user input is in dollar amount, not pennies.
@@ -949,7 +1230,7 @@ public class MvcControllerIntegTest {
     // No overdraft or numFraudReversals.
     double CUSTOMER1_BALANCE = 0;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     // Prepare Deposit Form to Deposit $100 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 100; // user input is in dollar amount, not pennies.
@@ -1031,12 +1312,16 @@ public class MvcControllerIntegTest {
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, 
                                                   CUSTOMER1_ID, 
                                                   CUSTOMER1_PASSWORD, 
+                                                  PASSWORD_ATTEMPTS,
+                                                  CUSTOMER_SECURITY_ANSWER,
                                                   CUSTOMER1_FIRST_NAME, 
                                                   CUSTOMER1_LAST_NAME, 
                                                   CUSTOMER1_BALANCE_IN_PENNIES, 
                                                   CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES,
                                                   CUSTOMER1_NUM_FRAUD_REVERSALS, 
-                                                  CUSTOMER1_NUM_INTEREST_DEPOSITS
+                                                  CUSTOMER1_NUM_INTEREST_DEPOSITS,
+                                                  CUSTOMER_RESET_PASSWORD_DAY,
+                                                  CUSTOMER_NEW_PASSWORD_FOR_RESET
                                                   );
     
     // Prepare Deposit Form to Deposit $100 to customer 1's account.
@@ -1082,12 +1367,12 @@ public class MvcControllerIntegTest {
     //Initialize customer1 with a balance of $1000. Balance will be represented as pennies in DB.
     double CUSTOMER1_BALANCE = 1000;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     //Initialize customer2 with a balance of $500. Balance will be represented as pennies in DB. 
     double CUSTOMER2_BALANCE = 500;
     int CUSTOMER2_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     //Amount to transfer
     double TRANSFER_AMOUNT = 100;
@@ -1134,7 +1419,7 @@ public class MvcControllerIntegTest {
     //Initialize customer1 with a balance of $1000. Balance will be represented as pennies in DB.
     double CUSTOMER1_BALANCE = 1000;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     //Initialize customer2 with a balance of $0 and Overdraft balance of $101. Balance will be represented as pennies in DB. 
     double CUSTOMER2_BALANCE = 0;
@@ -1142,7 +1427,7 @@ public class MvcControllerIntegTest {
     double CUSTOMER2_OVERDRAFT_BALANCE = 101.0;
     int CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_OVERDRAFT_BALANCE);
     int CUSTOMER2_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER2_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER2_NUM_FRAUD_REVERSALS, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     //Amount to transfer
     double TRANSFER_AMOUNT = 100;
@@ -1193,14 +1478,14 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     //Initialize customer1 with a balance of $1000. Balance will be represented as pennies in DB.
     double CUSTOMER1_BALANCE = 1000;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     double CUSTOMER2_BALANCE = 0;
     int CUSTOMER2_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_BALANCE);
     double CUSTOMER2_OVERDRAFT_BALANCE = 100.0;
     int CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_OVERDRAFT_BALANCE);
     int CUSTOMER2_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER2_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER2_NUM_FRAUD_REVERSALS, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
 
     //Transfer $150 from sender's account to recipient's account.
     double TRANSFER_AMOUNT = 150;
@@ -1342,8 +1627,8 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
 
     void initialize() throws ScriptException {
       int balanceInPennies = MvcControllerIntegTestHelpers.convertDollarsToPennies(initialBalanceInDollars);
-      MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
-              CUSTOMER1_LAST_NAME, balanceInPennies, MvcControllerIntegTestHelpers.convertDollarsToPennies(initialOverdraftBalanceInDollars), 0, 0);
+      MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, PASSWORD_ATTEMPTS, CUSTOMER_SECURITY_ANSWER, CUSTOMER1_FIRST_NAME,
+              CUSTOMER1_LAST_NAME, balanceInPennies, MvcControllerIntegTestHelpers.convertDollarsToPennies(initialOverdraftBalanceInDollars), 0, 0, CUSTOMER_RESET_PASSWORD_DAY, CUSTOMER_NEW_PASSWORD_FOR_RESET);
       for (Map.Entry<String, Double> initialBalance : initialCryptoBalance.entrySet()) {
         MvcControllerIntegTestHelpers.setCryptoBalance(dbDelegate, CUSTOMER1_ID, initialBalance.getKey(), initialBalance.getValue());
       }
@@ -1728,6 +2013,13 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
 
     cryptoTransactionTester.test(cryptoTransactionBuyETH);
 
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException error) {
+      error.printStackTrace();
+    }
+
+
     CryptoTransaction cryptoTransactionBuySOL = CryptoTransaction.builder()
             .expectedEndingBalanceInDollars(800)
             .expectedEndingCryptoBalance(0.1)
@@ -1740,6 +2032,12 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
 
     cryptoTransactionTester.test(cryptoTransactionBuySOL);
 
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException error) {
+      error.printStackTrace();
+    }
+
     CryptoTransaction cryptoTransactionSellSOL = CryptoTransaction.builder()
             .expectedEndingBalanceInDollars(900)
             .expectedEndingCryptoBalance(0.0)
@@ -1751,6 +2049,12 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
             .build();
 
     cryptoTransactionTester.test(cryptoTransactionSellSOL);
+
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException error) {
+      error.printStackTrace();
+    }
   }
 
   /**

--- a/src/test/resources/createDB.sql
+++ b/src/test/resources/createDB.sql
@@ -5,12 +5,18 @@ CREATE TABLE Customers (
   Balance int,
   OverdraftBalance int,
   NumFraudReversals int,
-  NumDepositsForInterest int
+  NumDepositsForInterest int,
+  ResetPasswordDay int
 );
 
 CREATE TABLE Passwords (
   CustomerID varchar(255),
-  Password varchar(255)
+  Password varchar(255),
+  PasswordAttempts int,
+  SecurityAnswer1 varchar(255),
+  SecurityAnswer2 varchar(255),
+  SecurityAnswer3 varchar(255),
+  NewPasswordForReset varchar(255)
 );
 
 CREATE TABLE OverdraftLogs (


### PR DESCRIPTION
**Changes Made in this PR:**

Customers of Testudo Bank require a robust mechanism for managing their security credentials, including reseting passwords and security questions. This need is particularly crucial given the risk associated with potential unauthorized access and fraudulent activities. By introducing an effective password and security question reset mechanism, customers will benefit from enhanced security and peace of mind, leading to increased customer satisfaction and retention.

---

`../python-sql-scripts/addCustomers.py`

- Added new fields to SQL statement to account for new schema, including PasswordAttempts, SecurityAnswer1, SecurityAnswer2, SecurityAnswer3, NewPasswordForReset, and ResetPasswordDay

---

`src/main/java/net/testudobank/MvcController.java`

- Added HTML GET request handlers for `/login_with_securityquestions`, `/securityquestions`, and `/resetpassword`
- Added HTML POST request handlers for `/login_with_securityquestions`, `/securityquestions`, and `/resetpassword`
- Altered `/login` POST handler to account for new schema.

---

`src/main/java/net/testudobank/TestudoBankRepository.java`

- Added new setters and getters for new fields according to new schema.

---

`src/main/java/net/testudobank/User.java`

- Added new fields according to new schema, including passwordAttempts, securityAnswer1, securityAnswer2, securityAnswer3, newPasswordForReset, and resetPasswordDay.

---

`src/main/webapp/...`

- Added pages `securityquestions_form` and `resetpassword_form` and `login_with_securityquestions` to have front end for setting security questions, resetting the password, and logging in with security questions after 3 failed attempts.
- Added features so`securityquestions_form` and `resetpassword_form` are both accessible from the `login` page, and `resetpassword_form` is accessible from `login_with_securityquestions`.

---

`src/test/resources/createDB.sql`

- Added `NumDepositsForInterest` and `ResetPasswordDay` to Customers Table
- Added `PasswordAttempts`, `SecurityAnswer1`, `SecurityAnswer2`, `SecurityAnswer3`, and `NewPasswordForReset` to Passwords Table

---

`src/test/java/net/testudobank/tests/MvcControllerIntegTest.java`

Simple Cases:
- User successfully resets password.
- User successfully sets security questions.
- User resets password with security questions set up.
- If user set up security questions, user is asked security questions aer 3 failed
attempts for password input.
Error Cases (return welcome.jsp page in all of these cases):
- User answers the security questions wrong aer failed attempts to login.
- User answers the security questions wrong when resetting password.
Edge Cases:
- User tries to login while a scheduled reset is already pending (ResetPasswordDay=0).

---

`src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java`

- Added new fields in function `addCustomerToDB` according to new schema.

---

**Future Changes to Make:**

- Verifying how to decrease password day count once a day.
- Improving UI of TestudoBank experience